### PR TITLE
Bug #51: Fix CMake usage message

### DIFF
--- a/cmake/macros/print_usage.cmake
+++ b/cmake/macros/print_usage.cmake
@@ -16,8 +16,4 @@ function(print_usage)
     message(STATUS "${Green} PAL is ready to build, usage:${ColorReset}")
     message(STATUS "${Yellow}    ${BUILD_COMMAND}${ColorReset}")
     message(STATUS "")
-
-    message(STATUS "${Green} For more build options:${ColorReset}")
-    message(STATUS "${Yellow}    ${BUILD_COMMAND} info${ColorReset}")
-    message(STATUS "")
 endfunction(print_usage)


### PR DESCRIPTION
Removed the "make info" target from the cmake info message

Signed-off-by: JaredWright <jared.wright12@gmail.com>