### PR TITLE
Missing cpuid

### DIFF
--- a/data/x86_64/register/control_register/xcr0.yml
+++ b/data/x86_64/register/control_register/xcr0.yml
@@ -1,0 +1,155 @@
+- name: xcr0
+  long_name: "Extended Control Register 0"
+  purpose: |
+      "
+      If CPUID.01H:ECX.XSAVE[bit 26] is 1, the processor supports one or more
+      extended control registers (XCRs).  Currently, the only such register
+      defined is XCR0. This register specifies the set of processor state
+      components for which the operating system provides context management,
+      e.g. x87 FPU state, SSE state, AVX state. The OS programs XCR0 to reflect
+      the features for which it provides context management.
+      "
+  size: 64
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: xgetbv
+        register: 0
+
+      - name: xsetbv
+        register: 0
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 64
+
+        fields:
+            - name: x87
+              long_name: "XCR0.X87 (bit 0)"
+              lsb: 0
+              msb: 0
+              readable: True
+              writable: True
+              description: |
+                  "
+                  XCR0.X87 (bit 0): This bit 0 must be 1. An attempt to write 0
+                  to this bit causes a #GP exception.
+                  "
+
+            - name: "SSE"
+              long_name: "XCR0.SSE (bit 1)"
+              lsb: 1
+              msb: 1
+              readable: True
+              writable: True
+              description: |
+                  "
+                  XCR0.SSE (bit 1): If 1, the XSAVE feature set can be used to
+                  manage MXCSR and the XMM registers (XMM0- XMM15 in 64-bit
+                  mode; otherwise XMM0-XMM7)
+                  "
+
+            - name: "AVX"
+              long_name: "XCR0.AVX (bit 2)"
+              lsb: 2
+              msb: 2
+              readable: True
+              writable: True
+              description: |
+                  "
+                  XCR0.AVX (bit 2): If 1, AVX instructions can be executed and
+                  the XSAVE feature set can be used to manage the upper halves
+                  of the YMM registers (YMM0-YMM15 in 64-bit mode; otherwise
+                  YMM0-YMM7)
+                  "
+
+            - name: "BNDREG"
+              long_name: "XCR0.BNDREG (bit 3)"
+              lsb: 3
+              msb: 3
+              readable: True
+              writable: True
+              description: |
+                  "
+                  XCR0.BNDREG (bit 3): If 1, MPX instructions can be executed
+                  and the XSAVE feature set can be used to manage the bounds
+                  registers BND0–BND3
+                  "
+
+            - name: "BNDCSR"
+              long_name: "XCR0.BNDCSR (bit 4)"
+              lsb: 4
+              msb: 4
+              readable: True
+              writable: True
+              description: |
+                  "
+                  XCR0.BNDCSR (bit 4): If 1, MPX instructions can be executed
+                  and the XSAVE feature set can be used to manage the BNDCFGU
+                  and BNDSTATUS registers
+                  "
+
+            - name: "opmask"
+              long_name: "XCR0.opmask (bit 5)"
+              lsb: 5
+              msb: 5
+              readable: True
+              writable: True
+              description: |
+                  "
+                  XCR0.opmask (bit 5): If 1, AVX-512 instructions can be
+                  executed and the XSAVE feature set can be used to manage the
+                  opmask registers k0–k7
+                  "
+
+            - name: "ZMM_Hi256"
+              long_name: "XCR0.ZMM_Hi256 (bit 6)"
+              lsb: 6
+              msb: 6
+              readable: True
+              writable: True
+              description: |
+                  "
+                  XCR0.ZMM_Hi256 (bit 6): If 1, AVX-512 instructions can be
+                  executed and the XSAVE feature set can be used to manage the
+                  upper halves of the lower ZMM registers (ZMM0-ZMM15 in 64-bit
+                  mode; otherwise ZMM0-ZMM7)
+                  "
+
+            - name: "Hi16_ZMM"
+              long_name: "XCR0.Hi16_ZMM (bit 7)"
+              lsb: 7
+              msb: 7
+              readable: True
+              writable: True
+              description: |
+                  "
+                  XCR0.Hi16_ZMM (bit 7): If 1, AVX-512 instructions can be
+                  executed and the XSAVE feature set can be used to manage the
+                  upper ZMM registers (ZMM16-ZMM31, only in 64-bit mode)
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 8
+              msb: 8
+              reserved0: True
+
+            - name: "PKRU"
+              long_name: "XCR0.PKRU (bit 9)"
+              lsb: 9
+              msb: 9
+              readable: True
+              writable: True
+              description: |
+                  "
+                  XCR0.PKRU (bit 9): If 1, the XSAVE feature set can be used to
+                  manage the PKRU register (see Section 2.7).
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 10
+              msb: 63
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_02_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_02_eax.yml
@@ -30,3 +30,15 @@
       - name: cpuid
         leaf: 0x2
         output: eax
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Cache and TLB Information"
+              long_name: "Cache and TLB Information"
+              lsb: 0
+              msb: 31
+              readable: True

--- a/data/x86_64/register/cpuid/leaf_02_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_02_ebx.yml
@@ -30,3 +30,15 @@
       - name: cpuid
         leaf: 0x2
         output: ebx
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Cache and TLB Information"
+              long_name: "Cache and TLB Information"
+              lsb: 0
+              msb: 31
+              readable: True

--- a/data/x86_64/register/cpuid/leaf_02_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_02_ecx.yml
@@ -30,3 +30,15 @@
       - name: cpuid
         leaf: 0x2
         output: ecx
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Cache and TLB Information"
+              long_name: "Cache and TLB Information"
+              lsb: 0
+              msb: 31
+              readable: True

--- a/data/x86_64/register/cpuid/leaf_02_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_02_edx.yml
@@ -30,3 +30,15 @@
       - name: cpuid
         leaf: 0x2
         output: edx
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Cache and TLB Information"
+              long_name: "Cache and TLB Information"
+              lsb: 0
+              msb: 31
+              readable: True

--- a/data/x86_64/register/cpuid/leaf_03_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_03_eax.yml
@@ -1,0 +1,21 @@
+- name: leaf_03_eax
+  long_name: "Basic CPUID Information"
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x3
+        output: eax
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_03_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_03_ebx.yml
@@ -1,0 +1,21 @@
+- name: leaf_03_ebx
+  long_name: "Basic CPUID Information"
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x3
+        output: ebx
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_09_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_09_ebx.yml
@@ -1,4 +1,4 @@
-- name: leaf_09_eax
+- name: leaf_09_ebx
   long_name: "Direct Cache Access Information Leaf"
   purpose: |
       "
@@ -12,7 +12,7 @@
       - name: cpuid
         leaf: 0x9
         uses_subleaf: True
-        output: eax
+        output: ebx
 
   fieldsets:
       - name: latest
@@ -20,13 +20,8 @@
         size: 32
 
         fields:
-            - name: "IA32_PLATFORM_DCA_CAP"
-              long_name: "IA32_PLATFORM_DCA_CAP"
+            - name: reserved
+              long_name: "Reserved"
               lsb: 0
               msb: 31
-              readable: True
-              description: |
-                  "
-                  Value of bits [31:0] of IA32_PLATFORM_DCA_CAP MSR (address
-                  1F8H).
-                  "
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_09_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_09_ecx.yml
@@ -1,4 +1,4 @@
-- name: leaf_09_eax
+- name: leaf_09_ecx
   long_name: "Direct Cache Access Information Leaf"
   purpose: |
       "
@@ -12,7 +12,7 @@
       - name: cpuid
         leaf: 0x9
         uses_subleaf: True
-        output: eax
+        output: ecx
 
   fieldsets:
       - name: latest
@@ -20,13 +20,8 @@
         size: 32
 
         fields:
-            - name: "IA32_PLATFORM_DCA_CAP"
-              long_name: "IA32_PLATFORM_DCA_CAP"
+            - name: reserved
+              long_name: "Reserved"
               lsb: 0
               msb: 31
-              readable: True
-              description: |
-                  "
-                  Value of bits [31:0] of IA32_PLATFORM_DCA_CAP MSR (address
-                  1F8H).
-                  "
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_09_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_09_edx.yml
@@ -1,4 +1,4 @@
-- name: leaf_09_eax
+- name: leaf_09_edx
   long_name: "Direct Cache Access Information Leaf"
   purpose: |
       "
@@ -12,7 +12,7 @@
       - name: cpuid
         leaf: 0x9
         uses_subleaf: True
-        output: eax
+        output: edx
 
   fieldsets:
       - name: latest
@@ -20,13 +20,8 @@
         size: 32
 
         fields:
-            - name: "IA32_PLATFORM_DCA_CAP"
-              long_name: "IA32_PLATFORM_DCA_CAP"
+            - name: reserved
+              long_name: "Reserved"
               lsb: 0
               msb: 31
-              readable: True
-              description: |
-                  "
-                  Value of bits [31:0] of IA32_PLATFORM_DCA_CAP MSR (address
-                  1F8H).
-                  "
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_0A_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_0A_eax.yml
@@ -18,7 +18,7 @@
   
   access_mechanisms:
       - name: cpuid
-        leaf: 0x7
+        leaf: 0xa
         output: eax
 
   fieldsets:

--- a/data/x86_64/register/cpuid/leaf_0A_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_0A_ebx.yml
@@ -18,7 +18,7 @@
   
   access_mechanisms:
       - name: cpuid
-        leaf: 0x7
+        leaf: 0xa
         output: ebx
 
   fieldsets:

--- a/data/x86_64/register/cpuid/leaf_0A_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_0A_ecx.yml
@@ -1,0 +1,34 @@
+- name: leaf_0A_ecx
+  long_name: "Architectural Performance Monitoring Leaf"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 0AH, the processor returns
+      information about support for architectural performance monitoring
+      capabilities. Architectural performance monitoring is supported if the
+      version ID (see Table 3-8) is greater than Pn 0. See Table 3-8.  For each
+      version of architectural performance monitoring capability, software must
+      enumerate this leaf to discover the programming facilities and the
+      architectural performance events available in the processor. The details
+      are described in Chapter 23, “Introduction to Virtual-Machine
+      Extensions,” in the Intel® 64 and IA-32 Architectures Software
+      Developer’s Manual, Volume 3C.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xa
+        output: ecx
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_0A_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_0A_edx.yml
@@ -18,7 +18,7 @@
   
   access_mechanisms:
       - name: cpuid
-        leaf: 0x7
+        leaf: 0xa
         output: edx
 
   fieldsets:

--- a/data/x86_64/register/cpuid/leaf_0B_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_0B_eax.yml
@@ -1,0 +1,44 @@
+- name: leaf_0B_eax
+  long_name: "Extended Topology Enumeration Leaf"
+  purpose: |
+      "
+      CPUID leaf 1FH is a preferred superset to leaf 0BH. Intel recommends
+      first checking for the existence of Leaf 1FH before using leaf 0BH.  When
+      CPUID executes with EAX set to 0BH, the processor returns information
+      about extended topology enumeration data. Software must detect the
+      presence of CPUID leaf 0BH by verifying (a) the highest leaf index
+      supported by CPUID is >= 0BH, and (b) CPUID.0BH:EBX[15:0] reports a
+      non-zero value. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xB
+        output: eax
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32
+
+        fields:
+            - name: "Bits 04 - 00"
+              long_name: "Bits 04 - 00"
+              lsb: 0
+              msb: 4
+              readable: True
+              description: |
+                  "
+                  Bits 04 - 00: Number of bits to shift right on x2APIC ID to
+                  get a unique topology ID of the next level type*.  All
+                  logical processors with the same next level ID share current
+                  level.
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 5
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_0B_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_0B_ebx.yml
@@ -1,0 +1,42 @@
+- name: leaf_0B_ebx
+  long_name: "Extended Topology Enumeration Leaf"
+  purpose: |
+      "
+      CPUID leaf 1FH is a preferred superset to leaf 0BH. Intel recommends
+      first checking for the existence of Leaf 1FH before using leaf 0BH.  When
+      CPUID executes with EAX set to 0BH, the processor returns information
+      about extended topology enumeration data. Software must detect the
+      presence of CPUID leaf 0BH by verifying (a) the highest leaf index
+      supported by CPUID is >= 0BH, and (b) CPUID.0BH:EBX[15:0] reports a
+      non-zero value. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xB
+        output: ebx
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32
+
+        fields:
+            - name: "Bits 15 - 00"
+              long_name: "Bits 15 - 00"
+              lsb: 0
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 00: Number of logical processors at this level
+                  type. The number reflects configuration as shipped by Intel
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16 
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_0B_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_0B_ecx.yml
@@ -1,0 +1,51 @@
+- name: leaf_0B_ecx
+  long_name: "Extended Topology Enumeration Leaf"
+  purpose: |
+      "
+      CPUID leaf 1FH is a preferred superset to leaf 0BH. Intel recommends
+      first checking for the existence of Leaf 1FH before using leaf 0BH.  When
+      CPUID executes with EAX set to 0BH, the processor returns information
+      about extended topology enumeration data. Software must detect the
+      presence of CPUID leaf 0BH by verifying (a) the highest leaf index
+      supported by CPUID is >= 0BH, and (b) CPUID.0BH:EBX[15:0] reports a
+      non-zero value. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xB
+        output: ecx
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32
+
+        fields:
+            - name: "Level number"
+              long_name: "Bits 07 - 00: Level number."
+              lsb: 0
+              msb: 7
+              readable: True
+              description: |
+                  "
+                  Bits 07 - 00: Level number. Same value in ECX input
+                  "
+
+            - name: "Level type"
+              long_name: "Bits 15 - 08: Level type"
+              lsb: 8
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 08: Level type
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16 
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_0B_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_0B_edx.yml
@@ -1,0 +1,35 @@
+- name: leaf_0B_edx
+  long_name: "Extended Topology Enumeration Leaf"
+  purpose: |
+      "
+      CPUID leaf 1FH is a preferred superset to leaf 0BH. Intel recommends
+      first checking for the existence of Leaf 1FH before using leaf 0BH.  When
+      CPUID executes with EAX set to 0BH, the processor returns information
+      about extended topology enumeration data. Software must detect the
+      presence of CPUID leaf 0BH by verifying (a) the highest leaf index
+      supported by CPUID is >= 0BH, and (b) CPUID.0BH:EBX[15:0] reports a
+      non-zero value. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xB
+        output: edx
+
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32
+
+        fields:
+            - name: "x2APIC ID"
+              long_name: "Bits 31 - 00: x2APIC ID"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31- 00: x2APIC ID the current logical processor
+                  "

--- a/data/x86_64/register/cpuid/leaf_0D_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_0D_eax.yml
@@ -1,0 +1,193 @@
+- name: leaf_0D_eax
+  long_name: "Processor Extended State Enumeration"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 0DH and ECX = 0, the processor
+      returns information about the bit-vector representation of all processor
+      state extensions that are supported in the processor and storage size
+      requirements of the XSAVE/XRSTOR area. See Table 3-8.  When CPUID
+      executes with EAX set to 0DH and ECX = n (n > 1, and is a valid sub-leaf
+      index), the processor returns information about the size and offset of
+      each processor extended state save area within the XSAVE/XRSTOR area.
+      See Table 3-8. Software can use the forward-extendable technique depicted
+      below to query the valid sub-leaves and obtain size and offset
+      information for each processor extended state save area: For i = 2 to 62
+      // sub-leaf 1 is reserved IF (CPUID.(EAX=0DH, ECX=0):VECTOR[i] = 1 ) //
+      VECTOR is the 64-bit value of EDX:EAX Execute CPUID.(EAX=0DH, ECX = i) to
+      examine size and offset for sub-leaf i; FI;
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xd
+        output: eax
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "x87 state"
+              long_name: "x87 state"
+              lsb: 0
+              msb: 0
+              readable: True
+              description: |
+                  "
+                  Bit 00: x87 state
+                  "
+
+            - name: "SSE state"
+              long_name: "SSE state"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01: SSE state
+                  "
+
+            - name: "AVX state"
+              long_name: "AVX state"
+              lsb: 2
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bit 02: AVX state
+                  "
+
+            - name: "MPX state"
+              long_name: "MPX state"
+              lsb: 3
+              msb: 4
+              readable: True
+              description: |
+                  "
+                  Bits 04 - 03: MPX state
+                  "
+
+            - name: "AVX-512 state"
+              long_name: "AVX-512 state"
+              lsb: 5
+              msb: 7
+              readable: True
+              description: |
+                  "
+                  Bits 07 - 05: AVX-512 state
+                  "
+
+            - name: "IA32_XSS"
+              long_name: "IA32_XSS"
+              lsb: 8
+              msb: 8
+              readable: True
+              description: |
+                  "
+                  Bit 08: Used for IA32_XSS
+                  "
+
+            - name: "PKRU state"
+              long_name: "PKRU state"
+              lsb: 9
+              msb: 9
+              readable: True
+              description: |
+                  "
+                  Bit 09: PKRU state
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 10
+              msb: 12
+              reserved0: True
+
+            - name: "IA32_XSS"
+              long_name: "IA32_XSS"
+              lsb: 13
+              msb: 13
+              readable: True
+              description: |
+                  "
+                  Bit 13: Used for IA32_XSS
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 14
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "XSAVEOPT is available"
+              long_name: "XSAVEOPT is available"
+              lsb: 0
+              msb: 0
+              readable: True
+              description: |
+                  "
+                  Bit 00: XSAVEOPT is available
+                  "
+
+            - name: "Bit 01"
+              long_name: "Bit 01"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01: Supports XSAVEC and the compacted form of XRSTOR if
+                  set
+                  "
+
+            - name: "Bit 02"
+              long_name: "Bit 02"
+              lsb: 2
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bit 02: Supports XGETBV with ECX = 1 if set
+                  "
+
+            - name: "Bit 03"
+              long_name: "Bit 03"
+              lsb: 3
+              msb: 3
+              readable: True
+              description: |
+                  "
+                  Bit 03: Supports XSAVES/XRSTORS and IA32_XSS if set
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 4
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) > 1"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 0"
+              long_name: "Bits 31 - 0"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 0: The size in bytes (from the offset specified in
+                  EBX) of the save area for an extended state feature
+                  associated with a valid sub-leaf index, n
+                  "

--- a/data/x86_64/register/cpuid/leaf_0D_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_0D_ebx.yml
@@ -1,0 +1,79 @@
+- name: leaf_0D_ebx
+  long_name: "Processor Extended State Enumeration"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 0DH and ECX = 0, the processor
+      returns information about the bit-vector representation of all processor
+      state extensions that are supported in the processor and storage size
+      requirements of the XSAVE/XRSTOR area. See Table 3-8.  When CPUID
+      executes with EAX set to 0DH and ECX = n (n > 1, and is a valid sub-leaf
+      index), the processor returns information about the size and offset of
+      each processor extended state save area within the XSAVE/XRSTOR area.
+      See Table 3-8. Software can use the forward-extendable technique depicted
+      below to query the valid sub-leaves and obtain size and offset
+      information for each processor extended state save area: For i = 2 to 62
+      // sub-leaf 1 is reserved IF (CPUID.(EAX=0DH, ECX=0):VECTOR[i] = 1 ) //
+      VECTOR is the 64-bit value of EDX:EAX Execute CPUID.(EAX=0DH, ECX = i) to
+      examine size and offset for sub-leaf i; FI;
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xd
+        output: ebx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: Maximum size (bytes, from the beginning of the
+                  XSAVE/XRSTOR save area) required by enabled features in XCR0.
+                  May be different than ECX if some features at the end of the
+                  XSAVE save area are not enabled
+                  "
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: The size in bytes of the XSAVE area containing
+                  all states enabled by XCRO | IA32_XSS
+                  "
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) > 1"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 0"
+              long_name: "Bits 31 - 0"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 0: The offset in bytes of this extended state
+                  component’s save area from the beginning of the XSAVE/XRSTOR
+                  area.  This field reports 0 if the sub-leaf index, n, does
+                  not map to a valid bit in the XCR0 register*
+                  "

--- a/data/x86_64/register/cpuid/leaf_0D_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_0D_ecx.yml
@@ -1,0 +1,139 @@
+- name: leaf_0D_ecx
+  long_name: "Processor Extended State Enumeration"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 0DH and ECX = 0, the processor
+      returns information about the bit-vector representation of all processor
+      state extensions that are supported in the processor and storage size
+      requirements of the XSAVE/XRSTOR area. See Table 3-8.  When CPUID
+      executes with EAX set to 0DH and ECX = n (n > 1, and is a valid sub-leaf
+      index), the processor returns information about the size and offset of
+      each processor extended state save area within the XSAVE/XRSTOR area.
+      See Table 3-8. Software can use the forward-extendable technique depicted
+      below to query the valid sub-leaves and obtain size and offset
+      information for each processor extended state save area: For i = 2 to 62
+      // sub-leaf 1 is reserved IF (CPUID.(EAX=0DH, ECX=0):VECTOR[i] = 1 ) //
+      VECTOR is the 64-bit value of EDX:EAX Execute CPUID.(EAX=0DH, ECX = i) to
+      examine size and offset for sub-leaf i; FI;
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xd
+        output: ecx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Bit 31 - 00"
+              long_name: "Bit 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 00: Maximum size (bytes, from the beginning of the
+                  XSAVE/XRSTOR save area) of the XSAVE/XRSTOR save area
+                  required by all supported features in the processor, i.e.,
+                  all the valid bit fields in XCR0
+                  "
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bits 07 - 00"
+              long_name: "Bits 07 - 00"
+              lsb: 0
+              msb: 7
+              readable: True
+              description: |
+                  "
+                  Bits 07 - 00: Used for XCR0
+                  "
+
+            - name: "PT state"
+              long_name: "PT state"
+              lsb: 8
+              msb: 8
+              readable: True
+              description: |
+                  "
+                  Bit 08: PT state
+                  "
+
+            - name: "Bit 09"
+              long_name: "Bit 09"
+              lsb: 9
+              msb: 9
+              readable: True
+              description: |
+                  "
+                  Bit 09: Used for XCR0
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 10
+              msb: 12
+              reserved0: True
+
+            - name: "HWP state"
+              long_name: "HWP state"
+              lsb: 13
+              msb: 13
+              readable: True
+              description: |
+                  "
+                  Bit 13: HWP state
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 14
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) > 1"
+        size: 32
+
+        fields:
+            - name: "Bit 00"
+              long_name: "Bit 00"
+              lsb: 0
+              msb: 0
+              readable: True
+              description: |
+                  "
+                  Bit 00 is set if the bit n (corresponding to the sub-leaf
+                  index) is supported in the IA32_XSS MSR; it is clear if bit n
+                  is instead supported in XCR0
+                  "
+
+            - name: "Bit 01"
+              long_name: "Bit 01"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01 is set if, when the compacted format of an XSAVE area
+                  is used, this extended state component located on the next
+                  64-byte boundary following the preceding state component
+                  (otherwise, it is located immediately following the preceding
+                  state component)
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 2
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_0D_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_0D_edx.yml
@@ -1,0 +1,71 @@
+- name: leaf_0D_edx
+  long_name: "Processor Extended State Enumeration"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 0DH and ECX = 0, the processor
+      returns information about the bit-vector representation of all processor
+      state extensions that are supported in the processor and storage size
+      requirements of the XSAVE/XRSTOR area. See Table 3-8.  When CPUID
+      executes with EAX set to 0DH and ECX = n (n > 1, and is a valid sub-leaf
+      index), the processor returns information about the size and offset of
+      each processor extended state save area within the XSAVE/XRSTOR area.
+      See Table 3-8. Software can use the forward-extendable technique depicted
+      below to query the valid sub-leaves and obtain size and offset
+      information for each processor extended state save area: For i = 2 to 62
+      // sub-leaf 1 is reserved IF (CPUID.(EAX=0DH, ECX=0):VECTOR[i] = 1 ) //
+      VECTOR is the 64-bit value of EDX:EAX Execute CPUID.(EAX=0DH, ECX = i) to
+      examine size and offset for sub-leaf i; FI;
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xd
+        output: edx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Bit 31 - 00"
+              long_name: "Bit 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 00: Reports the supported bits of the upper 32 bits
+                  of XCR0. XCR0[n+32] can be set to 1 only if EDX[n] is 1
+                  "
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: Reports the supported bits of the upper 32 bits
+                  of the IA32_XSS MSR. IA32_XSS[n+32] can be set to 1 only if
+                  EDX[n] is 1
+                  "
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) > 1"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_0F_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_0F_eax.yml
@@ -1,0 +1,51 @@
+- name: leaf_0F_eax
+  long_name: |
+      "
+      Returns Intel Resource Director Technology (Intel RDT) Monitoring
+      Enumeration Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 0FH and ECX = 0, the processor
+      returns information about the bit-vector representation of QoS monitoring
+      resource types that are supported in the processor and maximum range of
+      RMID values the processor can use to monitor of any supported resource
+      types. Each bit, starting from bit 1, corresponds to a specific resource
+      type if the bit is set. The bit position corresponds to the sub-leaf
+      index (or ResID) that software must use to query QoS monitoring
+      capability available for that type. See Table 3-8.  When CPUID executes
+      with EAX set to 0FH and ECX = n (n >= 1, and is a valid ResID), the
+      processor returns information software can use to program IA32_PQR_ASSOC,
+      IA32_QM_EVTSEL MSRs before reading QoS data from the IA32_QM_CTR MSR
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xf
+        output: eax
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_0F_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_0F_ebx.yml
@@ -1,0 +1,62 @@
+- name: leaf_0F_ebx
+  long_name: |
+      "
+      Returns Intel Resource Director Technology (Intel RDT) Monitoring
+      Enumeration Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 0FH and ECX = 0, the processor
+      returns information about the bit-vector representation of QoS monitoring
+      resource types that are supported in the processor and maximum range of
+      RMID values the processor can use to monitor of any supported resource
+      types. Each bit, starting from bit 1, corresponds to a specific resource
+      type if the bit is set. The bit position corresponds to the sub-leaf
+      index (or ResID) that software must use to query QoS monitoring
+      capability available for that type. See Table 3-8.  When CPUID executes
+      with EAX set to 0FH and ECX = n (n >= 1, and is a valid ResID), the
+      processor returns information software can use to program IA32_PQR_ASSOC,
+      IA32_QM_EVTSEL MSRs before reading QoS data from the IA32_QM_CTR MSR
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xf
+        output: ebx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: Maximum range (zero-based) of RMID within this
+                  physical processor of all types
+                  "
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: Conversion factor from reported IA32_QM_CTR
+                  value to occupancy metric (bytes) and Memory Bandwidth
+                  Monitoring (MBM) metrics
+                  "

--- a/data/x86_64/register/cpuid/leaf_0F_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_0F_ecx.yml
@@ -1,0 +1,55 @@
+- name: leaf_0F_ecx
+  long_name: |
+      "
+      Returns Intel Resource Director Technology (Intel RDT) Monitoring
+      Enumeration Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 0FH and ECX = 0, the processor
+      returns information about the bit-vector representation of QoS monitoring
+      resource types that are supported in the processor and maximum range of
+      RMID values the processor can use to monitor of any supported resource
+      types. Each bit, starting from bit 1, corresponds to a specific resource
+      type if the bit is set. The bit position corresponds to the sub-leaf
+      index (or ResID) that software must use to query QoS monitoring
+      capability available for that type. See Table 3-8.  When CPUID executes
+      with EAX set to 0FH and ECX = n (n >= 1, and is a valid ResID), the
+      processor returns information software can use to program IA32_PQR_ASSOC,
+      IA32_QM_EVTSEL MSRs before reading QoS data from the IA32_QM_CTR MSR
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xf
+        output: ecx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Maximum range (zero-based) of RMID of this resource type
+                  "

--- a/data/x86_64/register/cpuid/leaf_0F_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_0F_edx.yml
@@ -1,0 +1,97 @@
+- name: leaf_0F_edx
+  long_name: |
+      "
+      Returns Intel Resource Director Technology (Intel RDT) Monitoring
+      Enumeration Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 0FH and ECX = 0, the processor
+      returns information about the bit-vector representation of QoS monitoring
+      resource types that are supported in the processor and maximum range of
+      RMID values the processor can use to monitor of any supported resource
+      types. Each bit, starting from bit 1, corresponds to a specific resource
+      type if the bit is set. The bit position corresponds to the sub-leaf
+      index (or ResID) that software must use to query QoS monitoring
+      capability available for that type. See Table 3-8.  When CPUID executes
+      with EAX set to 0FH and ECX = n (n >= 1, and is a valid ResID), the
+      processor returns information software can use to program IA32_PQR_ASSOC,
+      IA32_QM_EVTSEL MSRs before reading QoS data from the IA32_QM_CTR MSR
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0xf
+        output: edx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 0
+              reserved0: True
+
+            - name: "Bit 01"
+              long_name: "Bit 01"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01: Supports L3 Cache Intel RDT Monitoring if 1
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 2
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bit 00"
+              long_name: "Bit 00"
+              lsb: 0
+              msb: 0
+              readable: True
+              description: |
+                  "
+                  Bit 00: Supports L3 occupancy monitoring if 1
+                  "
+
+            - name: "Bit 01"
+              long_name: "Bit 01"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01: Supports L3 Total Bandwidth monitoring if 1
+                  "
+
+            - name: "Bit 02"
+              long_name: "Bit 02"
+              lsb: 2
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bit 02: Supports L3 Local Bandwidth monitoring if 1
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 3
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_10_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_10_eax.yml
@@ -1,0 +1,107 @@
+- name: leaf_10_eax
+  long_name: |
+      "
+      Returns Intel Resource Director Technology (Intel RDT) Allocation
+      Enumeration Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 10H and ECX = 0, the processor
+      returns information about the bit-vector representation of QoS
+      Enforcement resource types that are supported in the processor. Each bit,
+      starting from bit 1, corresponds to a specific resource type if the bit
+      is set. The bit position corresponds to the sub-leaf index (or ResID)
+      that software must use to query QoS enforcement capability available for
+      that type. See Table 3-8.  When CPUID executes with EAX set to 10H and
+      ECX = n (n >= 1, and is a valid ResID), the processor returns information
+      about available classes of service and range of QoS mask MSRs that
+      software can use to configure each class of services using capability bit
+      masks in the QoS Mask registers, IA32_resourceType_Mask_n
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x10
+        output: eax
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bits 04 - 00"
+              long_name: "Bits 04 - 00"
+              lsb: 0
+              msb: 4
+              readable: True
+              description: |
+                  "
+                  Bits 04 - 00: Length of the capacity bit mask for the
+                  corresponding ResID using minus-one notation
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 5
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_2
+        condition: "Fieldset valid for subleaf (ECX) = 2"
+        size: 32
+
+        fields:
+            - name: "Bits 04 - 00"
+              long_name: "Bits 04 - 00"
+              lsb: 0
+              msb: 4
+              readable: True
+              description: |
+                  "
+                  Bits 04 - 00: Length of the capacity bit mask for the
+                  corresponding ResID using minus-one notation
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 5
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_3
+        condition: "Fieldset valid for subleaf (ECX) = 3"
+        size: 32
+
+        fields:
+            - name: "Bits 11 - 00"
+              long_name: "Bits 11 - 00"
+              lsb: 0
+              msb: 11
+              readable: True
+              description: |
+                  "
+                  Bits 11 - 00: Reports the maximum MBA throttling value
+                  supported for the corresponding ResID using minus-one
+                  notation
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 12
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_10_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_10_ebx.yml
@@ -1,0 +1,119 @@
+- name: leaf_10_ebx
+  long_name: |
+      "
+      Returns Intel Resource Director Technology (Intel RDT) Allocation
+      Enumeration Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 10H and ECX = 0, the processor
+      returns information about the bit-vector representation of QoS
+      Enforcement resource types that are supported in the processor. Each bit,
+      starting from bit 1, corresponds to a specific resource type if the bit
+      is set. The bit position corresponds to the sub-leaf index (or ResID)
+      that software must use to query QoS enforcement capability available for
+      that type. See Table 3-8.  When CPUID executes with EAX set to 10H and
+      ECX = n (n >= 1, and is a valid ResID), the processor returns information
+      about available classes of service and range of QoS mask MSRs that
+      software can use to configure each class of services using capability bit
+      masks in the QoS Mask registers, IA32_resourceType_Mask_n
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x10
+        output: ebx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 0
+              reserved0: True
+
+            - name: "Bit 01"
+              long_name: "Bit 01"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01: Supports L3 Cache Allocation Technology if 1
+                  "
+
+            - name: "Bit 02"
+              long_name: "Bit 02"
+              lsb: 2
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bit 02: Supports L2 Cache Allocation Technology if 1
+                  "
+
+            - name: "Bit 03"
+              long_name: "Bit 03"
+              lsb: 3
+              msb: 3
+              readable: True
+              description: |
+                  "
+                  Bit 03: Supports Memory Bandwidth Allocation if 1
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 4
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: Bit-granular map of isolation/contention of
+                  allocation units
+                  "
+
+      - name: subleaf_2
+        condition: "Fieldset valid for subleaf (ECX) = 2"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: Bit-granular map of isolation/contention of
+                  allocation units
+                  "
+
+      - name: subleaf_3
+        condition: "Fieldset valid for subleaf (ECX) = 3"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_10_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_10_ecx.yml
@@ -1,0 +1,107 @@
+- name: leaf_10_ecx
+  long_name: |
+      "
+      Returns Intel Resource Director Technology (Intel RDT) Allocation
+      Enumeration Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 10H and ECX = 0, the processor
+      returns information about the bit-vector representation of QoS
+      Enforcement resource types that are supported in the processor. Each bit,
+      starting from bit 1, corresponds to a specific resource type if the bit
+      is set. The bit position corresponds to the sub-leaf index (or ResID)
+      that software must use to query QoS enforcement capability available for
+      that type. See Table 3-8.  When CPUID executes with EAX set to 10H and
+      ECX = n (n >= 1, and is a valid ResID), the processor returns information
+      about available classes of service and range of QoS mask MSRs that
+      software can use to configure each class of services using capability bit
+      masks in the QoS Mask registers, IA32_resourceType_Mask_n
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x10
+        output: ecx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 1
+              reserved0: True
+
+            - name: "Bit 02"
+              long_name: "Bit 02"
+              lsb: 2
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bit 02: Code and Data Prioritization Technology supported if
+                  1
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 3
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_2
+        condition: "Fieldset valid for subleaf (ECX) = 2"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_3
+        condition: "Fieldset valid for subleaf (ECX) = 3"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 1
+              reserved0: True
+
+            - name: "Bit 02"
+              long_name: "Bit 02"
+              lsb: 2
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bit 02: Reports whether the response of the delay values is
+                  linear
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 3
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_10_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_10_edx.yml
@@ -1,0 +1,103 @@
+- name: leaf_10_edx
+  long_name: |
+      "
+      Returns Intel Resource Director Technology (Intel RDT) Allocation
+      Enumeration Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 10H and ECX = 0, the processor
+      returns information about the bit-vector representation of QoS
+      Enforcement resource types that are supported in the processor. Each bit,
+      starting from bit 1, corresponds to a specific resource type if the bit
+      is set. The bit position corresponds to the sub-leaf index (or ResID)
+      that software must use to query QoS enforcement capability available for
+      that type. See Table 3-8.  When CPUID executes with EAX set to 10H and
+      ECX = n (n >= 1, and is a valid ResID), the processor returns information
+      about available classes of service and range of QoS mask MSRs that
+      software can use to configure each class of services using capability bit
+      masks in the QoS Mask registers, IA32_resourceType_Mask_n
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x10
+        output: edx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bits 15 - 00"
+              long_name: "Bits 15 - 00"
+              lsb: 0
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 00: Highest COS number supported for this ResID
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_2
+        condition: "Fieldset valid for subleaf (ECX) = 2"
+        size: 32
+
+        fields:
+            - name: "Bits 15 - 00"
+              long_name: "Bits 15 - 00"
+              lsb: 0
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 00: Highest COS number supported for this ResID
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_3
+        condition: "Fieldset valid for subleaf (ECX) = 3"
+        size: 32
+
+        fields:
+            - name: "Bits 15 - 00"
+              long_name: "Bits 15 - 00"
+              lsb: 0
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 00: Highest COS number supported for this ResID
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_12_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_12_eax.yml
@@ -1,0 +1,129 @@
+- name: leaf_12_eax
+  long_name: "Returns Intel SGX Enumeration Information"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 12H and ECX = 0H, the processor
+      returns information about Intel SGX capabilities. See Table 3-8.  When
+      CPUID executes with EAX set to 12H and ECX = 1H, the processor returns
+      information about Intel SGX attributes. See Table 3-8.  When CPUID
+      executes with EAX set to 12H and ECX = n (n > 1), the processor returns
+      information about Intel SGX Enclave Page Cache. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x12
+        output: eax
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "SGX1"
+              long_name: "SGX1"
+              lsb: 0
+              msb: 0
+              readable: True
+              description: |
+                  "
+                  Bit 00: SGX1. If 1, Indicates Intel SGX supports the
+                  collection of SGX1 leaf functions
+                  "
+
+            - name: "SGX2"
+              long_name: "SGX2"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01: SGX2. If 1, Indicates Intel SGX supports the
+                  collection of SGX2 leaf functions
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 2
+              msb: 4
+              reserved0: True
+
+            - name: "Bit 05"
+              long_name: "Bit 05"
+              lsb: 5
+              msb: 5
+              readable: True
+              description: |
+                  "
+                  Bit 05: If 1, indicates Intel SGX supports ENCLV instruction
+                  leaves EINCVIRTCHILD, EDECVIRTCHILD, and ESETCONTEXT
+                  "
+
+            - name: "Bit 06"
+              long_name: "Bit 06"
+              lsb: 6
+              msb: 6
+              readable: True
+              description: |
+                  "
+                  Bit 06: If 1, indicates Intel SGX supports ENCLS instruction
+                  leaves ETRACKC, ERDINFO, ELDBC, and ELDUC
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 7
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bit 31 - 00"
+              long_name: "Bit 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 00: Reports the valid bits of SECS.ATTRIBUTES[31:0]
+                  that software can set with ECREATE
+                  "
+
+      - name: subleaf_2
+        condition: "Fieldset valid for subleaf (ECX) = 2"
+        size: 32
+
+        fields:
+            - name: "Sub-leaf Type"
+              long_name: "Sub-leaf Type"
+              lsb: 0
+              msb: 3
+              readable: True
+              description: |
+                  "
+                  Bit 03 - 00: Sub-leaf Type
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 4
+              msb: 11
+              reserved0: True
+
+            - name: "EAX[31:12]"
+              long_name: "EAX[31:12]"
+              lsb: 12
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  EAX[31:12]: Bits 31:12 of the physical address of the base of
+                  the EPC section
+                  "

--- a/data/x86_64/register/cpuid/leaf_12_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_12_ebx.yml
@@ -1,0 +1,74 @@
+- name: leaf_12_ebx
+  long_name: "Returns Intel SGX Enumeration Information"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 12H and ECX = 0H, the processor
+      returns information about Intel SGX capabilities. See Table 3-8.  When
+      CPUID executes with EAX set to 12H and ECX = 1H, the processor returns
+      information about Intel SGX attributes. See Table 3-8.  When CPUID
+      executes with EAX set to 12H and ECX = n (n > 1), the processor returns
+      information about Intel SGX Enclave Page Cache. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x12
+        output: ebx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: MISCSELECT. Bit vector of supported extended
+                  SGX features
+                  "
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bit 31 - 00"
+              long_name: "Bit 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 00: Reports the valid bits of SECS.ATTRIBUTES[63:32]
+                  that software can set with ECREATE
+                  "
+
+      - name: subleaf_2
+        condition: "Fieldset valid for subleaf (ECX) = 2"
+        size: 32
+
+        fields:
+            - name: "EBX[19:00]"
+              long_name: "EBX[19:00]"
+              lsb: 0
+              msb: 19
+              readable: True
+              description: |
+                  "
+                  EBX[19:00]: Bits 51:32 of the physical address of the base of
+                  the EPC section
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 20
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_12_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_12_ecx.yml
@@ -1,0 +1,83 @@
+- name: leaf_12_ecx
+  long_name: "Returns Intel SGX Enumeration Information"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 12H and ECX = 0H, the processor
+      returns information about Intel SGX capabilities. See Table 3-8.  When
+      CPUID executes with EAX set to 12H and ECX = 1H, the processor returns
+      information about Intel SGX attributes. See Table 3-8.  When CPUID
+      executes with EAX set to 12H and ECX = n (n > 1), the processor returns
+      information about Intel SGX Enclave Page Cache. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x12
+        output: ecx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True
+
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bit 31 - 00"
+              long_name: "Bit 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 00: Reports the valid bits of SECS.ATTRIBUTES[95:64]
+                  that software can set with ECREATE
+                  "
+
+      - name: subleaf_2
+        condition: "Fieldset valid for subleaf (ECX) = 2"
+        size: 32
+
+        fields:
+            - name: "ECX[03:00]"
+              long_name: "ECX[03:00]"
+              lsb: 0
+              msb: 3
+              readable: True
+              description: |
+                  "
+                  ECX[03:00]: EPC section property encoding defined as follows:
+                  If EAX[3:0] 0000b, then all bits of the EDX:ECX pair are
+                  enumerated as 0.  If EAX[3:0] 0001b, then this section
+                  has confidentiality and integrity protection.
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 4
+              msb: 11
+              reserved0: True
+
+            - name: "ECX[31:12]"
+              long_name: "ECX[31:12]"
+              lsb: 12
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  ECX[31:12]: Bits 31:12 of the size of the corresponding EPC
+                  section within the Processor Reserved Memory
+                  "

--- a/data/x86_64/register/cpuid/leaf_12_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_12_edx.yml
@@ -1,0 +1,92 @@
+- name: leaf_12_edx
+  long_name: "Returns Intel SGX Enumeration Information"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 12H and ECX = 0H, the processor
+      returns information about Intel SGX capabilities. See Table 3-8.  When
+      CPUID executes with EAX set to 12H and ECX = 1H, the processor returns
+      information about Intel SGX attributes. See Table 3-8.  When CPUID
+      executes with EAX set to 12H and ECX = n (n > 1), the processor returns
+      information about Intel SGX Enclave Page Cache. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x12
+        output: edx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "MaxEnclaveSize_Not64"
+              long_name: "MaxEnclaveSize_Not64"
+              lsb: 0
+              msb: 7
+              readable: True
+              description: |
+                  "
+                  Bits 07 - 00: MaxEnclaveSize_Not64. The maximum supported
+                  enclave size in non-64-bit mode is 2^(EDX[7:0])
+                  "
+
+            - name: "Bits 15 - 08"
+              long_name: "Bits 15 - 08"
+              lsb: 8
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 08: MaxEnclaveSize_64. The maximum supported
+                  enclave size in 64-bit mode is 2^(EDX[15:8])
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16
+              msb: 31
+              reserved0: True
+
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bit 31 - 00"
+              long_name: "Bit 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 00: Reports the valid bits of
+                  SECS.ATTRIBUTES[127:96] that software can set with ECREATE
+                  "
+
+      - name: subleaf_2
+        condition: "Fieldset valid for subleaf (ECX) = 2"
+        size: 32
+
+        fields:
+            - name: "EDX[19:00]"
+              long_name: "EDX[19:00]"
+              lsb: 0
+              msb: 19
+              readable: True
+              description: |
+                  "
+                  EDX[19:00]: Bits 51:32 of the size of the corresponding EPC
+                  section within the Processor Reserved Memory
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 20
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_14_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_14_eax.yml
@@ -1,0 +1,68 @@
+- name: leaf_14_eax
+  long_name: "Returns Intel Processor Trace Enumeration Information"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 14H and ECX = 0H, the processor
+      returns information about Intel Processor Trace extensions. See Table
+      3-8.  When CPUID executes with EAX set to 14H and ECX = n (n > 0 and less
+      than the number of non-zero bits in CPUID.(EAX=14H, ECX= 0H).EAX), the
+      processor returns information about packet generation in Intel Processor
+      Trace. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x14
+        output: eax
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: Reports the maximum sub-leaf supported in leaf
+                  14H
+                  "
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bits 02 - 00"
+              long_name: "Bits 02 - 00"
+              lsb: 0
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bits 02 - 00: Number of configurable Address Ranges for
+                  filtering
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 3
+              msb: 15
+              reserved0: True
+
+            - name: "Bits 31 - 16"
+              long_name: "Bits 31 - 16"
+              lsb: 16
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 16: Bitmap of supported MTC period encodings
+                  "

--- a/data/x86_64/register/cpuid/leaf_14_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_14_ebx.yml
@@ -1,0 +1,127 @@
+- name: leaf_14_ebx
+  long_name: "Returns Intel Processor Trace Enumeration Information"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 14H and ECX = 0H, the processor
+      returns information about Intel Processor Trace extensions. See Table
+      3-8.  When CPUID executes with EAX set to 14H and ECX = n (n > 0 and less
+      than the number of non-zero bits in CPUID.(EAX=14H, ECX= 0H).EAX), the
+      processor returns information about packet generation in Intel Processor
+      Trace. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x14
+        output: ebx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Bit 00"
+              long_name: "Bit 00"
+              lsb: 0
+              msb: 0
+              readable: True
+              description: |
+                  "
+                  Bit 00: If 1, indicates that IA32_RTIT_CTL.CR3Filter can be
+                  set to 1, and that IA32_RTIT_CR3_MATCH MSR can be accessed
+                  "
+
+            - name: "Bit 01"
+              long_name: "Bit 01"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01: If 1, indicates support of Configurable PSB and
+                  Cycle-Accurate Mode
+                  "
+
+            - name: "Bit 02"
+              long_name: "Bit 02"
+              lsb: 2
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bit 02: If 1, indicates support of IP Filtering, TraceStop
+                  filtering, and preservation of Intel PT MSRs across warm
+                  reset
+                  "
+
+            - name: "Bit 03"
+              long_name: "Bit 03"
+              lsb: 3
+              msb: 3
+              readable: True
+              description: |
+                  "
+                  Bit 03: If 1, indicates support of MTC timing packet and
+                  suppression of COFI-based packets
+                  "
+
+            - name: "Bit 04"
+              long_name: "Bit 04"
+              lsb: 4
+              msb: 4
+              readable: True
+              description: |
+                  "
+                  Bit 04: If 1, indicates support of PTWRITE. Writes can set
+                  IA32_RTIT_CTL[12] (PTWEn) and IA32_RTIT_CTL[5] (FUPonPTW),
+                  and PTWRITE can generate packets
+                  "
+
+            - name: "Bit 05"
+              long_name: "Bit 05"
+              lsb: 5
+              msb: 5
+              readable: True
+              description: |
+                  "
+                  Bit 05: If 1, indicates support of Power Event Trace. Writes
+                  can set IA32_RTIT_CTL[4] (PwrEvtEn), enabling Power Event
+                  Trace packet generation
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 6
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: "Bits 15 - 00"
+              long_name: "Bits 15 - 00"
+              lsb: 0
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 00: Bitmap of supported Cycle Threshold value
+                  encodings
+                  "
+
+            - name: "Bits 31 - 16"
+              long_name: "Bits 31 - 16"
+              lsb: 13
+              msb: 13
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 16: Bitmap of supported Configurable PSB frequency
+                  encodings
+                  "

--- a/data/x86_64/register/cpuid/leaf_14_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_14_ecx.yml
@@ -1,0 +1,99 @@
+- name: leaf_14_ecx
+  long_name: "Returns Intel Processor Trace Enumeration Information"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 14H and ECX = 0H, the processor
+      returns information about Intel Processor Trace extensions. See Table
+      3-8.  When CPUID executes with EAX set to 14H and ECX = n (n > 0 and less
+      than the number of non-zero bits in CPUID.(EAX=14H, ECX= 0H).EAX), the
+      processor returns information about packet generation in Intel Processor
+      Trace. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x14
+        output: ecx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Bit 00"
+              long_name: "Bit 00"
+              lsb: 0
+              msb: 0
+              readable: True
+              description: |
+                  "
+                  Bit 00: If 1, Tracing can be enabled with IA32_RTIT_CTL.ToPA
+                  = 1, hence utilizing the ToPA output scheme;
+                  IA32_RTIT_OUTPUT_BASE and IA32_RTIT_OUTPUT_MASK_PTRS MSRs can
+                  be accessed
+                  "
+
+            - name: "Bit 01"
+              long_name: "Bit 01"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01: If 1, ToPA tables can hold any number of output
+                  entries, up to the maximum allowed by the MaskOrTableOffset
+                  field of IA32_RTIT_OUTPUT_MASK_PTRS
+                  "
+
+            - name: "Bit 02"
+              long_name: "Bit 02"
+              lsb: 2
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bit 02: If 1, indicates support of Single-Range Output scheme
+                  "
+
+            - name: "Bit 03"
+              long_name: "Bit 03"
+              lsb: 3
+              msb: 3
+              readable: True
+              description: |
+                  "
+                  Bit 03: If 1, indicates support of output to Trace Transport
+                  subsystem
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 4
+              msb: 30
+              reserved0: True
+
+            - name: "Bit 31"
+              long_name: "Bit 31"
+              lsb: 31
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31: If 1, generated packets which contain IP payloads
+                  have LIP values, which include the CS base component
+                  "
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_14_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_14_edx.yml
@@ -1,0 +1,42 @@
+- name: leaf_14_edx
+  long_name: "Returns Intel Processor Trace Enumeration Information"
+  purpose: |
+      "
+      When CPUID executes with EAX set to 14H and ECX = 0H, the processor
+      returns information about Intel Processor Trace extensions. See Table
+      3-8.  When CPUID executes with EAX set to 14H and ECX = n (n > 0 and less
+      than the number of non-zero bits in CPUID.(EAX=14H, ECX= 0H).EAX), the
+      processor returns information about packet generation in Intel Processor
+      Trace. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x14
+        output: edx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1
+        condition: "Fieldset valid for subleaf (ECX) = 1"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_15_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_15_eax.yml
@@ -1,0 +1,35 @@
+- name: leaf_15_eax
+  long_name: |
+      "
+      Returns Time Stamp Counter and Nominal Core Crystal Clock Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 15H and ECX = 0H, the processor
+      returns information about Time Stamp Counter and Core Crystal Clock. See
+      Table 3-8
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x15
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: An unsigned integer which is the denominator of
+                  the TSC/”core crystal clock” ratio
+                  "

--- a/data/x86_64/register/cpuid/leaf_15_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_15_ebx.yml
@@ -1,0 +1,35 @@
+- name: leaf_15_ebx
+  long_name: |
+      "
+      Returns Time Stamp Counter and Nominal Core Crystal Clock Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 15H and ECX = 0H, the processor
+      returns information about Time Stamp Counter and Core Crystal Clock. See
+      Table 3-8
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x15
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: An unsigned integer which is the numerator of
+                  the TSC/”core crystal clock” ratio
+                  "

--- a/data/x86_64/register/cpuid/leaf_15_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_15_ecx.yml
@@ -1,0 +1,35 @@
+- name: leaf_15_ecx
+  long_name: |
+      "
+      Returns Time Stamp Counter and Nominal Core Crystal Clock Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 15H and ECX = 0H, the processor
+      returns information about Time Stamp Counter and Core Crystal Clock. See
+      Table 3-8
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x15
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: An unsigned integer which is the nominal
+                  frequency of the core crystal clock in Hz
+                  "

--- a/data/x86_64/register/cpuid/leaf_15_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_15_edx.yml
@@ -1,0 +1,30 @@
+- name: leaf_15_edx
+  long_name: |
+      "
+      Returns Time Stamp Counter and Nominal Core Crystal Clock Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 15H and ECX = 0H, the processor
+      returns information about Time Stamp Counter and Core Crystal Clock. See
+      Table 3-8
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x15
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_16_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_16_eax.yml
@@ -1,0 +1,39 @@
+- name: leaf_16_eax
+  long_name: |
+      "
+      Returns Processor Frequency Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 16H, the processor returns
+      information about Processor Frequency Information. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x16
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Base Frequency"
+              long_name: "Processor Base Frequency"
+              lsb: 0
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 00: Processor Base Frequency (in MHz)
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_16_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_16_ebx.yml
@@ -1,0 +1,39 @@
+- name: leaf_16_ebx
+  long_name: |
+      "
+      Returns Processor Frequency Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 16H, the processor returns
+      information about Processor Frequency Information. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x16
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Maximum Frequency"
+              long_name: "Maximum Frequency"
+              lsb: 0
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 00: Maximum Frequency (in MHz).
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_16_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_16_ecx.yml
@@ -1,0 +1,39 @@
+- name: leaf_16_ecx
+  long_name: |
+      "
+      Returns Processor Frequency Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 16H, the processor returns
+      information about Processor Frequency Information. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x16
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Bus Frequency"
+              long_name: "Bus Frequency"
+              lsb: 0
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 00: Bus (Reference) Frequency (in MHz)
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_16_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_16_edx.yml
@@ -1,0 +1,29 @@
+- name: leaf_16_edx
+  long_name: |
+      "
+      Returns Processor Frequency Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 16H, the processor returns
+      information about Processor Frequency Information. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x16
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_17_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_17_eax.yml
@@ -1,0 +1,62 @@
+- name: leaf_17_eax
+  long_name: |
+      "
+      Returns System-On-Chip Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 17H, the processor returns
+      information about the System-On-Chip Vendor Attribute Enumeration. See
+      Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x17
+        output: eax
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "MaxSOCID_Index"
+              long_name: "MaxSOCID_Index"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                   Bits 31 - 00: MaxSOCID_Index. Reports the maximum input
+                   value of supported sub-leaf in leaf 17H
+                  "
+
+      - name: subleaf_1_3
+        condition: "Fieldset valid for subleaf (ECX) between 1 and 3"
+        size: 32
+
+        fields:
+            - name: "SOC Vendor Brand String"
+              long_name: "SOC Vendor Brand String"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 00: SOC Vendor Brand String. UTF-8 encoded string
+                  "
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) > MaxSOCID_Index"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_17_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_17_ebx.yml
@@ -1,0 +1,79 @@
+- name: leaf_17_ebx
+  long_name: |
+      "
+      Returns System-On-Chip Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 17H, the processor returns
+      information about the System-On-Chip Vendor Attribute Enumeration. See
+      Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x17
+        output: ebx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "SOC Vendor ID"
+              long_name: "SOC Vendor ID"
+              lsb: 0
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 00: SOC Vendor ID
+                  "
+
+            - name: "IsVendorScheme"
+              long_name: "IsVendorScheme"
+              lsb: 16
+              msb: 16
+              readable: True
+              description: |
+                  "
+                  Bit 16: IsVendorScheme. If 1, the SOC Vendor ID field is
+                  assigned via an industry standard enumeration scheme.
+                  Otherwise, the SOC Vendor ID field is assigned by Intel
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 17
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_1_3
+        condition: "Fieldset valid for subleaf (ECX) between 1 and 3"
+        size: 32
+
+        fields:
+            - name: "SOC Vendor Brand String"
+              long_name: "SOC Vendor Brand String"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 00: SOC Vendor Brand String. UTF-8 encoded string
+                  "
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) > MaxSOCID_Index"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_17_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_17_ecx.yml
@@ -1,0 +1,62 @@
+- name: leaf_17_ecx
+  long_name: |
+      "
+      Returns System-On-Chip Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 17H, the processor returns
+      information about the System-On-Chip Vendor Attribute Enumeration. See
+      Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x17
+        output: ecx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Project ID"
+              long_name: "Project ID"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: Project ID. A unique number an SOC vendor
+                  assigns to its SOC projects
+                  "
+
+      - name: subleaf_1_3
+        condition: "Fieldset valid for subleaf (ECX) between 1 and 3"
+        size: 32
+
+        fields:
+            - name: "SOC Vendor Brand String"
+              long_name: "SOC Vendor Brand String"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 00: SOC Vendor Brand String. UTF-8 encoded string
+                  "
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) > MaxSOCID_Index"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_17_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_17_edx.yml
@@ -1,0 +1,62 @@
+- name: leaf_17_edx
+  long_name: |
+      "
+      Returns System-On-Chip Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 17H, the processor returns
+      information about the System-On-Chip Vendor Attribute Enumeration. See
+      Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x17
+        output: edx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Stepping ID"
+              long_name: "Stepping ID"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: Stepping ID. A unique number within an SOC
+                  project that an SOC vendor assigns
+                  "
+
+      - name: subleaf_1_3
+        condition: "Fieldset valid for subleaf (ECX) between 1 and 3"
+        size: 32
+
+        fields:
+            - name: "SOC Vendor Brand String"
+              long_name: "SOC Vendor Brand String"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bit 31 - 00: SOC Vendor Brand String. UTF-8 encoded string
+                  "
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) > MaxSOCID_Index"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_18_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_18_eax.yml
@@ -1,0 +1,47 @@
+- name: leaf_18_eax
+  long_name: |
+      "
+      Returns Deterministic Address Translation Parameters Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 18H, the processor returns
+      information about the Deterministic Address Translation Parameters. See
+      Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x18
+        output: eax
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Bits 31 - 00"
+              long_name: "Bits 31 - 00"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: Reports the maximum input value of supported
+                  sub-leaf in leaf 18H.
+                  "
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) >= 1"
+        size: 32
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_18_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_18_ebx.yml
@@ -1,0 +1,176 @@
+- name: leaf_18_ebx
+  long_name: |
+      "
+      Returns Deterministic Address Translation Parameters Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 18H, the processor returns
+      information about the Deterministic Address Translation Parameters. See
+      Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x18
+        output: ebx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Bit 00"
+              long_name: "Bit 00"
+              lsb: 0
+              msb: 0
+              readable: True
+              description: |
+                  "
+                  Bit 00: 4K page size entries supported by this structure
+                  "
+
+            - name: "Bit 01"
+              long_name: "Bit 01"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01: 2MB page size entries supported by this structure
+                  "
+
+            - name: "Bit 02"
+              long_name: "Bit 02"
+              lsb: 2
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bit 02: 4MB page size entries supported by this structure
+                  "
+
+            - name: "Bit 03"
+              long_name: "Bit 03"
+              lsb: 3
+              msb: 3
+              readable: True
+              description: |
+                  "
+                  Bit 03: 1 GB page size entries supported by this structure
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 4
+              msb: 7
+              reserved0: True
+
+            - name: "Partitioning"
+              long_name: "Partitioning"
+              lsb: 8
+              msb: 10
+              readable: True
+              description: |
+                  "
+                  Bits 10 - 08: Partitioning (0: Soft partitioning between the
+                  logical processors sharing this structure)
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 11
+              msb: 15
+              reserved0: True
+
+            - name: "W"
+              long_name: "W"
+              lsb: 16
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 16: W = Ways of associativity
+                  "
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) >= 1"
+        size: 32
+
+        fields:
+            - name: "Bit 00"
+              long_name: "Bit 00"
+              lsb: 0
+              msb: 0
+              readable: True
+              description: |
+                  "
+                  Bit 00: 4K page size entries supported by this structure
+                  "
+
+            - name: "Bit 01"
+              long_name: "Bit 01"
+              lsb: 1
+              msb: 1
+              readable: True
+              description: |
+                  "
+                  Bit 01: 2MB page size entries supported by this structure
+                  "
+
+            - name: "Bit 02"
+              long_name: "Bit 02"
+              lsb: 2
+              msb: 2
+              readable: True
+              description: |
+                  "
+                  Bit 02: 4MB page size entries supported by this structure
+                  "
+
+            - name: "Bit 03"
+              long_name: "Bit 03"
+              lsb: 3
+              msb: 3
+              readable: True
+              description: |
+                  "
+                  Bit 03: 1 GB page size entries supported by this structure
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 4
+              msb: 7
+              reserved0: True
+
+            - name: "Partitioning"
+              long_name: "Partitioning"
+              lsb: 8
+              msb: 10
+              readable: True
+              description: |
+                  "
+                  Bits 10 - 08: Partitioning (0: Soft partitioning between the
+                  logical processors sharing this structure)
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 11
+              msb: 15
+              reserved0: True
+
+            - name: "W"
+              long_name: "W"
+              lsb: 16
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 16: W = Ways of associativity
+                  "

--- a/data/x86_64/register/cpuid/leaf_18_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_18_ecx.yml
@@ -1,0 +1,50 @@
+- name: leaf_18_ecx
+  long_name: |
+      "
+      Returns Deterministic Address Translation Parameters Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 18H, the processor returns
+      information about the Deterministic Address Translation Parameters. See
+      Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x18
+        output: ecx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "S"
+              long_name: "S"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: S = Number of Sets
+                  "
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) >= 1"
+        size: 32
+
+        fields:
+            - name: "S"
+              long_name: "S"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 00: S = Number of Sets
+                  "

--- a/data/x86_64/register/cpuid/leaf_18_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_18_edx.yml
@@ -1,0 +1,136 @@
+- name: leaf_18_edx
+  long_name: |
+      "
+      Returns Deterministic Address Translation Parameters Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 18H, the processor returns
+      information about the Deterministic Address Translation Parameters. See
+      Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  is_indexed: True
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x18
+        output: edx
+
+  fieldsets:
+      - name: subleaf_0
+        condition: "Fieldset valid for subleaf (ECX) = 0"
+        size: 32
+
+        fields:
+            - name: "Translation cache type"
+              long_name: "Translation cache type"
+              lsb: 0
+              msb: 4
+              readable: True
+              description: |
+                  "
+                  Bits 04 - 00: Translation cache type field
+                  "
+
+            - name: "Translation cache level"
+              long_name: "Translation cache level"
+              lsb: 5
+              msb: 7
+              readable: True
+              description: |
+                  "
+                  Bits 07 - 05: Translation cache level (starts at 1)
+                  "
+
+            - name: "Fully associative structure"
+              long_name: "Fully associative structure"
+              lsb: 8
+              msb: 8
+              readable: True
+              description: |
+                  "
+                  Bit 08: Fully associative structure
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 9
+              msb: 13
+              reserved0: True
+
+            - name: "Bits 25- 14"
+              long_name: "Bits 25- 14"
+              lsb: 14
+              msb: 25
+              readable: True
+              description: |
+                  "
+                  Bits 25- 14: Maximum number of addressable IDs for logical
+                  processors sharing this translation cache
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 26
+              msb: 31
+              reserved0: True
+
+      - name: subleaf_n
+        condition: "Fieldset valid for subleaf (ECX) >= 1"
+        size: 32
+
+        fields:
+            - name: "Translation cache type"
+              long_name: "Translation cache type"
+              lsb: 0
+              msb: 4
+              readable: True
+              description: |
+                  "
+                  Bits 04 - 00: Translation cache type field
+                  "
+
+            - name: "Translation cache level"
+              long_name: "Translation cache level"
+              lsb: 5
+              msb: 7
+              readable: True
+              description: |
+                  "
+                  Bits 07 - 05: Translation cache level (starts at 1)
+                  "
+
+            - name: "Fully associative structure"
+              long_name: "Fully associative structure"
+              lsb: 8
+              msb: 8
+              readable: True
+              description: |
+                  "
+                  Bit 08: Fully associative structure
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 9
+              msb: 13
+              reserved0: True
+
+            - name: "Bits 25- 14"
+              long_name: "Bits 25- 14"
+              lsb: 14
+              msb: 25
+              readable: True
+              description: |
+                  "
+                  Bits 25- 14: Maximum number of addressable IDs for logical
+                  processors sharing this translation cache
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 26
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_1a_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_1a_eax.yml
@@ -1,0 +1,47 @@
+- name: leaf_1A_eax
+  long_name: |
+      "
+      Returns Hybrid Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 1AH, the processor returns
+      information about hybrid capabilities. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x1a
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Native model ID"
+              long_name: "Native model ID"
+              lsb: 0
+              msb: 23
+              readable: True
+              description: |
+                  "
+                  Bits 23-0: Native model ID of the core. The core-type and
+                  native mode ID can be used to uniquely identify the
+                  microarchitecture of the core. This native model ID is not
+                  unique across core types, and not related to the model ID
+                  reported in CPUID leaf 01h, and does not identify the SOC
+                  "
+
+            - name: "Core type"
+              long_name: "Core type"
+              lsb: 24
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31-24: Core type
+                  "

--- a/data/x86_64/register/cpuid/leaf_1a_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_1a_ebx.yml
@@ -1,0 +1,29 @@
+- name: leaf_1A_ebx
+  long_name: |
+      "
+      Returns Hybrid Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 1AH, the processor returns
+      information about hybrid capabilities. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x1a
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_1a_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_1a_ecx.yml
@@ -1,0 +1,29 @@
+- name: leaf_1A_ecx
+  long_name: |
+      "
+      Returns Hybrid Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 1AH, the processor returns
+      information about hybrid capabilities. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x1a
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_1a_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_1a_edx.yml
@@ -1,0 +1,29 @@
+- name: leaf_1A_edx
+  long_name: |
+      "
+      Returns Hybrid Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 1AH, the processor returns
+      information about hybrid capabilities. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x1a
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_1f_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_1f_eax.yml
@@ -1,0 +1,45 @@
+- name: leaf_1F_eax
+  long_name: |
+      "
+      Returns V2 Extended Topology Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 1FH, the processor returns
+      information about extended topology enumeration data. Software must
+      detect the presence of CPUID leaf 1FH by verifying (a) the highest leaf
+      index supported by CPUID is >= 1FH, and (b) CPUID.1FH:EBX[15:0] reports a
+      non-zero value. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x1f
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Bits 04 - 00"
+              long_name: "Bits 04 - 00"
+              lsb: 0
+              msb: 4
+              readable: True
+              description: |
+                  "
+                  Bits 04 - 00: Number of bits to shift right on x2APIC ID to
+                  get a unique topology ID of the next level type*.  All
+                  logical processors with the same next level ID share current
+                  level.
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 5
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_1f_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_1f_ebx.yml
@@ -1,0 +1,43 @@
+- name: leaf_1F_ebx
+  long_name: |
+      "
+      Returns V2 Extended Topology Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 1FH, the processor returns
+      information about extended topology enumeration data. Software must
+      detect the presence of CPUID leaf 1FH by verifying (a) the highest leaf
+      index supported by CPUID is >= 1FH, and (b) CPUID.1FH:EBX[15:0] reports a
+      non-zero value. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x1f
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Bits 15 - 00"
+              long_name: "Bits 15 - 00"
+              lsb: 0
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 00: Number of logical processors at this level
+                  type. The number reflects configuration as shipped by Intel
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_1f_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_1f_ecx.yml
@@ -1,0 +1,52 @@
+- name: leaf_1F_ecx
+  long_name: |
+      "
+      Returns V2 Extended Topology Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 1FH, the processor returns
+      information about extended topology enumeration data. Software must
+      detect the presence of CPUID leaf 1FH by verifying (a) the highest leaf
+      index supported by CPUID is >= 1FH, and (b) CPUID.1FH:EBX[15:0] reports a
+      non-zero value. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x1f
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Level number"
+              long_name: "Level number"
+              lsb: 0
+              msb: 7
+              readable: True
+              description: |
+                  "
+                  Bits 07 - 00: Level number. Same value in ECX input
+                  "
+
+            - name: "Level type"
+              long_name: "Level type"
+              lsb: 8
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 08: Level type
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_1f_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_1f_edx.yml
@@ -1,0 +1,36 @@
+- name: leaf_1F_edx
+  long_name: |
+      "
+      Returns V2 Extended Topology Information
+      "
+  purpose: |
+      "
+      When CPUID executes with EAX set to 1FH, the processor returns
+      information about extended topology enumeration data. Software must
+      detect the presence of CPUID leaf 1FH by verifying (a) the highest leaf
+      index supported by CPUID is >= 1FH, and (b) CPUID.1FH:EBX[15:0] reports a
+      non-zero value. See Table 3-8.
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x1f
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "x2APIC ID"
+              long_name: "x2APIC ID"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31- 00: x2APIC ID the current logical processor
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000000_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_80000000_eax.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000000_eax
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000000
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Maximum Input Value"
+              long_name: "Maximum Input Value"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Maximum Input Value for Extended Function CPUID Information
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000000_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000000_ebx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000000_ebx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000000
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000000_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000000_ecx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000000_ecx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000000
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000000_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000000_edx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000000_edx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000000
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000001_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_80000001_eax.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000001_eax
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000001
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Extended Processor Signature and Feature Bits"
+              long_name: "Extended Processor Signature and Feature Bits"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Extended Processor Signature and Feature Bits
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000001_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000001_ebx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000001_ebx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000001
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000001_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000001_ecx.yml
@@ -1,0 +1,66 @@
+- name: leaf_80000001_ecx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000001
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Bit 00"
+              long_name: "Bit 00"
+              lsb: 0
+              msb: 0
+              readable: True
+              description: |
+                  "
+                  Bit 00: LAHF/SAHF available in 64-bit mode.
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 1
+              msb: 4
+              reserved0: True
+
+            - name: "LZCNT"
+              long_name: "LZCNT"
+              lsb: 5
+              msb: 5
+              readable: True
+              description: |
+                  "
+                  Bit 05: LZCNT
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 6
+              msb: 7
+              reserved0: True
+
+            - name: "PREFETCHW"
+              long_name: "PREFETCHW"
+              lsb: 8
+              msb: 8
+              readable: True
+              description: |
+                  "
+                  Bit 08: PREFETCHW
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 9
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000001_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000001_edx.yml
@@ -1,0 +1,98 @@
+- name: leaf_80000001_edx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000001
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 10
+              reserved0: True
+
+            - name: "SYSCALL/SYSRET"
+              long_name: "SYSCALL/SYSRET"
+              lsb: 11
+              msb: 11
+              readable: True
+              description: |
+                  "
+                  Bit 11: SYSCALL/SYSRET
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 12
+              msb: 19
+              reserved0: True
+
+            - name: "Execute Disable Bit available"
+              long_name: "Execute Disable Bit available"
+              lsb: 20
+              msb: 20
+              readable: True
+              description: |
+                  "
+                  Bit 20: Execute Disable Bit available.
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 21
+              msb: 25
+              reserved0: True
+
+            - name: "Bit 26"
+              long_name: "Bit 26"
+              lsb: 26
+              msb: 26
+              readable: True
+              description: |
+                  "
+                  Bit 26: 1-GByte pages are available if 1
+                  "
+
+            - name: "Bit 27"
+              long_name: "Bit 27"
+              lsb: 27
+              msb: 27
+              readable: True
+              description: |
+                  "
+                  Bit 27: RDTSCP and IA32_TSC_AUX are available if 1
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 28
+              msb: 28
+              reserved0: True
+
+            - name: "Bit 29"
+              long_name: "Bit 29"
+              lsb: 29
+              msb: 29
+              readable: True
+              description: |
+                  "
+                  Bit 29: Intel® 64 Architecture available if 1.
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 30
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000002_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_80000002_eax.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000002_eax
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000002
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String"
+              long_name: "Processor Brand String"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000002_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000002_ebx.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000002_ebx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000002
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000002_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000002_ecx.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000002_ecx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000002
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000002_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000002_edx.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000002_edx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000002
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000003_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_80000003_eax.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000003_eax
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000003
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000003_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000003_ebx.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000003_ebx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000003
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000003_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000003_ecx.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000003_ecx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000003
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000003_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000003_edx.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000003_edx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000003
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000004_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_80000004_eax.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000004_eax
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000004
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000004_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000004_ebx.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000004_ebx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000004
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000004_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000004_ecx.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000004_ecx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000004
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000004_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000004_edx.yml
@@ -1,0 +1,28 @@
+- name: leaf_80000004_edx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000004
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Processor Brand String Continued"
+              long_name: "Processor Brand String Continued"
+              lsb: 0
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Processor Brand String Continued
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000006_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_80000006_eax.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000006_eax
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000006
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000006_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000006_ebx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000006_ebx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000006
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000006_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000006_ecx.yml
@@ -1,0 +1,54 @@
+- name: leaf_80000006_ecx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000006
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Cache Line size"
+              long_name: "Cache Line size"
+              lsb: 0
+              msb: 7
+              readable: True
+              description: |
+                  "
+                  Bits 07 - 00: Cache Line size in bytes
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 8
+              msb: 11
+              reserved0: True
+
+            - name: "L2 Associativity"
+              long_name: "L2 Associativity"
+              lsb: 12
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 12: L2 Associativity field
+                  "
+
+            - name: "Cache size"
+              long_name: "Cache size"
+              lsb: 16
+              msb: 31
+              readable: True
+              description: |
+                  "
+                  Bits 31 - 16: Cache size in 1K units
+                  "

--- a/data/x86_64/register/cpuid/leaf_80000006_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000006_edx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000006_edx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000006
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000007_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_80000007_eax.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000007_eax
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000007
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000007_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000007_ebx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000007_ebx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000007
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000007_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000007_ecx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000007_ecx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000007
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000007_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000007_edx.yml
@@ -1,0 +1,40 @@
+- name: leaf_80000007_edx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000007
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 7
+              reserved0: True
+
+            - name: "Invariant TSC"
+              long_name: "Invariant TSC"
+              lsb: 8
+              msb: 8
+              readable: True
+              description: |
+                  "
+                  Bit 08: Invariant TSC available if 1.
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 9
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000008_eax.yml
+++ b/data/x86_64/register/cpuid/leaf_80000008_eax.yml
@@ -1,0 +1,44 @@
+- name: leaf_80000008_eax
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000008
+        output: eax
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: "Physical Address Bits"
+              long_name: "Physical Address Bits"
+              lsb: 0
+              msb: 7
+              readable: True
+              description: |
+                  "
+                  Bits 07 - 00: #Physical Address Bits
+                  "
+
+            - name: "Linear Address Bits"
+              long_name: "Linear Address Bits"
+              lsb: 8
+              msb: 15
+              readable: True
+              description: |
+                  "
+                  Bits 15 - 08: #Linear Address Bits
+                  "
+
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 16
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000008_ebx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000008_ebx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000008_ebx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000008
+        output: ebx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000008_ecx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000008_ecx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000008_ecx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000008
+        output: ecx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/data/x86_64/register/cpuid/leaf_80000008_edx.yml
+++ b/data/x86_64/register/cpuid/leaf_80000008_edx.yml
@@ -1,0 +1,24 @@
+- name: leaf_80000008_edx
+  long_name: |
+      "
+      Extended Function CPUID Information
+      "
+  size: 32
+  arch: x86_64
+  
+  access_mechanisms:
+      - name: cpuid
+        leaf: 0x80000008
+        output: edx
+  
+  fieldsets:
+      - name: latest
+        condition: "Fieldset valid on latest version of the Intel architecture"
+        size: 32 
+
+        fields:
+            - name: reserved
+              long_name: "Reserved"
+              lsb: 0
+              msb: 31
+              reserved0: True

--- a/pal/model/x86_64/access_mechanism/__init__.py
+++ b/pal/model/x86_64/access_mechanism/__init__.py
@@ -5,3 +5,5 @@ from .mov_read import MOVRead
 from .mov_write import MOVWrite
 from .vmread import VMRead
 from .vmwrite import VMWrite
+from .xgetbv import XGETBV
+from .xsetbv import XSETBV

--- a/pal/model/x86_64/access_mechanism/xgetbv.py
+++ b/pal/model/x86_64/access_mechanism/xgetbv.py
@@ -1,0 +1,25 @@
+from pal.model.access_mechanism import AbstractAccessMechanism
+from dataclasses import dataclass
+
+@dataclass()
+class XGETBV(AbstractAccessMechanism):
+    """ Access mechanism reading an extended control register using the """
+    """ x86 XGETBV instruction """
+
+    register: int = 0
+    """ The register number to be read """
+
+    name: str = "xgetbv"
+    """ The name of this access mechanism  """
+
+    def is_read(self):
+        return True
+
+    def is_write(self):
+        return False
+
+    def is_memory_mapped(self):
+        return False
+
+    def is_valid(self):
+        return True

--- a/pal/model/x86_64/access_mechanism/xsetbv.py
+++ b/pal/model/x86_64/access_mechanism/xsetbv.py
@@ -1,0 +1,25 @@
+from pal.model.access_mechanism import AbstractAccessMechanism
+from dataclasses import dataclass
+
+@dataclass()
+class XSETBV(AbstractAccessMechanism):
+    """ Access mechanism writing to an extended control register using the """
+    """ x86 XSETBV instruction """
+
+    register: int = 0
+    """ The register number to be read """
+
+    name: str = "xsetbv"
+    """ The name of this access mechanism  """
+
+    def is_read(self):
+        return False
+
+    def is_write(self):
+        return True
+
+    def is_memory_mapped(self):
+        return False
+
+    def is_valid(self):
+        return True

--- a/pal/model/x86_64/register.py
+++ b/pal/model/x86_64/register.py
@@ -46,4 +46,6 @@ class x86_64Register(Register):
             "wrmsr": [],
             "vmread": [],
             "vmwrite": [],
+            "xgetbv": [],
+            "xsetbv": [],
         })

--- a/pal/parser/pal_model_parser.py
+++ b/pal/parser/pal_model_parser.py
@@ -113,6 +113,18 @@ class PalModelParser(AbstractParser):
                 am.encoding = am_yml["encoding"]
                 register.access_mechanisms["vmwrite"].append(am)
 
+            elif am_yml["name"] == "xgetbv":
+                am = pal.model.x86_64.access_mechanism.XGETBV()
+                am.name = am_yml["name"]
+                am.register = am_yml["register"]
+                register.access_mechanisms["xgetbv"].append(am)
+
+            elif am_yml["name"] == "xsetbv":
+                am = pal.model.x86_64.access_mechanism.XSETBV()
+                am.name = am_yml["name"]
+                am.register = am_yml["register"]
+                register.access_mechanisms["xsetbv"].append(am)
+
             elif am_yml["name"] == "mrs_register":
                 am = pal.model.armv8a.access_mechanism.MRSRegister()
                 am.name = am_yml["name"]


### PR DESCRIPTION
This patch series adds:

* Many missing CPUID data definitions
* Support for reading/writing extended control registers (XCR0)