### PR TITLE
April 2020 Release

### DIFF
--- a/pal/generator/c_header_generator.py
+++ b/pal/generator/c_header_generator.py
@@ -30,10 +30,14 @@ class CHeaderGenerator(AbstractGenerator):
                 include_guard = "PAL_" + reg.name.upper() + "_H"
                 self.gadgets["pal.include_guard"].name = include_guard
                 self.gadgets["pal.header_depends"].includes = [
-                    "<stdint.h>",
-                    "<stdio.h>",
-                    "<inttypes.h>"
+                    "<stdint.h>"
                 ]
+
+                if config.print_mechanism == "printf_utf8":
+                    self.gadgets["pal.header_depends"].includes.extend([
+                        "<stdio.h>",
+                        "<inttypes.h>"
+                    ])
 
                 outfile_path = os.path.join(outpath, reg.name.lower() + ".h")
                 outfile_path = os.path.abspath(outfile_path)

--- a/pal/generator/cxx_header_generator.py
+++ b/pal/generator/cxx_header_generator.py
@@ -27,10 +27,14 @@ class CxxHeaderGenerator(AbstractGenerator):
                 include_guard = "PAL_" + reg.name.upper() + "_H"
                 self.gadgets["pal.include_guard"].name = include_guard
                 self.gadgets["pal.header_depends"].includes = [
-                    "<stdint.h>",
-                    "<stdio.h>",
-                    "<inttypes.h>"
+                    "<stdint.h>"
                 ]
+
+                if config.print_mechanism == "printf_utf8":
+                    self.gadgets["pal.header_depends"].includes.extend([
+                        "<stdio.h>",
+                        "<inttypes.h>"
+                    ])
 
                 outfile_path = os.path.join(outpath, reg.name.lower() + ".h")
                 outfile_path = os.path.abspath(outfile_path)

--- a/pal/writer/access_mechanism/gas_x86_64_att_syntax.py
+++ b/pal/writer/access_mechanism/gas_x86_64_att_syntax.py
@@ -97,7 +97,7 @@ class GasX86_64AttSyntaxAccessMechanismWriter(AccessMechanismWriter):
                                       access_mechanism, result):
         self._write_inline_assembly(outfile, [
                 "mov $" + str(hex(access_mechanism.encoding)) + ", %%rdi",
-                "vmread %%rdi, %[v]",
+                "vmread %%rdi, %q[v]",
             ],
             outputs='[v] "=r"(' + str(result) + ')',
             clobbers='"rdi"'
@@ -141,7 +141,7 @@ class GasX86_64AttSyntaxAccessMechanismWriter(AccessMechanismWriter):
                                        access_mechanism, value):
         self._write_inline_assembly(outfile, [
                 "mov $" + str(hex(access_mechanism.encoding)) + ", %%rdi",
-                "vmwrite %[v], %%rdi",
+                "vmwrite %q[v], %%rdi",
             ],
             inputs='[v] "r"(' + value + ')',
             clobbers='"rdi"'

--- a/pal/writer/access_mechanism/gas_x86_64_intel_syntax.py
+++ b/pal/writer/access_mechanism/gas_x86_64_intel_syntax.py
@@ -97,7 +97,7 @@ class GasX86_64IntelSyntaxAccessMechanismWriter(AccessMechanismWriter):
                                       access_mechanism, result):
         self._write_inline_assembly(outfile, [
                 "mov rdi, " + str(hex(access_mechanism.encoding)),
-                "vmread %[v], rdi",
+                "vmread %q[v], rdi",
             ],
             outputs='[v] "=r"(' + str(result) + ')',
             clobbers='"rdi"'
@@ -141,7 +141,7 @@ class GasX86_64IntelSyntaxAccessMechanismWriter(AccessMechanismWriter):
                                        access_mechanism, value):
         self._write_inline_assembly(outfile, [
                 "mov rdi, " + str(hex(access_mechanism.encoding)),
-                "vmwrite rdi, %[v]",
+                "vmwrite rdi, %q[v]",
             ],
             inputs='[v] "r"(' + value + ')',
             clobbers='"rdi"'

--- a/test/c++11/intel_x64/CMakeLists.txt
+++ b/test/c++11/intel_x64/CMakeLists.txt
@@ -10,7 +10,8 @@ set(SOURCES
     leaf_04.cpp
     leaf_0D.cpp
     eptp.cpp
-    facs.cpp
+    guest_interrupt_status.cpp
+    # facs.cpp
     main.cpp
 )
 

--- a/test/c++11/intel_x64/guest_interrupt_status.cpp
+++ b/test/c++11/intel_x64/guest_interrupt_status.cpp
@@ -1,0 +1,20 @@
+#include <pal/vmcs/guest_interrupt_status.h>
+
+void test_guest_interrupt_status_compile(void)
+{
+    // Register accessors
+    pal::guest_interrupt_status::set(0xA55A);
+    auto value = pal::guest_interrupt_status::get();
+
+    // Field accessors
+    pal::guest_interrupt_status::rvi::get();
+    pal::guest_interrupt_status::rvi::get(value);
+    pal::guest_interrupt_status::rvi::set(0x0);
+    pal::guest_interrupt_status::rvi::set(0x0, value);
+
+    // Printers
+    pal::guest_interrupt_status::dump();
+    pal::guest_interrupt_status::dump(value);
+    pal::guest_interrupt_status::rvi::dump();
+    pal::guest_interrupt_status::rvi::dump(value);
+}

--- a/test/c/intel_x64/CMakeLists.txt
+++ b/test/c/intel_x64/CMakeLists.txt
@@ -10,7 +10,8 @@ set(SOURCES
     leaf_04.c
     leaf_0D.c
     eptp.c
-    facs.c
+    guest_interrupt_status.c
+    # facs.c
     main.c
 )
 

--- a/test/c/intel_x64/guest_interrupt_status.c
+++ b/test/c/intel_x64/guest_interrupt_status.c
@@ -1,0 +1,20 @@
+#include <pal/vmcs/guest_interrupt_status.h>
+
+void test_guest_interrupt_status_compile(void)
+{
+    // Register accessors
+    pal_guest_interrupt_status_set(0xA55A);
+    uint16_t value = pal_guest_interrupt_status_get();
+
+    // Field accessors
+    pal_guest_interrupt_status_rvi_get();
+    pal_guest_interrupt_status_rvi_get_from_value(value);
+    pal_guest_interrupt_status_rvi_set(0x0);
+    pal_guest_interrupt_status_rvi_set_from_value(0x0, value);
+
+    // Printers
+    pal_guest_interrupt_status_dump();
+    pal_guest_interrupt_status_dump_from_value(value);
+    pal_guest_interrupt_status_rvi_dump();
+    pal_guest_interrupt_status_rvi_dump_from_value(value);
+}


### PR DESCRIPTION
* Bug fix for VMCS fields that aren't 64 bits wide
* Removed header dependencies for printf while PAL is configured with a different print mechanism