### PR TITLE
libpal: fix builds using libpal

### DIFF
--- a/libpal/CMakeLists.txt
+++ b/libpal/CMakeLists.txt
@@ -3,4 +3,5 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
 
     add_library(libpal cpuid_x64.asm)
     set_target_properties(libpal PROPERTIES OUTPUT_NAME pal)
+    target_include_directories(libpal PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 endif()

--- a/libpal/libpal.h
+++ b/libpal/libpal.h
@@ -34,6 +34,9 @@ typedef struct pal_cpuid_register_values {
     uint32_t edx;
 } pal_cpuid_register_values;
 
-extern "C" pal_cpuid_register_values pal_execute_cpuid(uint32_t eax, uint32_t ecx);
+#ifdef __cplusplus
+extern "C"
+#endif
+pal_cpuid_register_values pal_execute_cpuid(uint32_t eax, uint32_t ecx);
 
 #endif

--- a/pal/generator/c_header_generator.py
+++ b/pal/generator/c_header_generator.py
@@ -41,7 +41,8 @@ class CHeaderGenerator(AbstractGenerator):
 
                 if config.access_mechanism == "libpal":
                     self.gadgets["pal.header_depends"].includes.extend([
-                        "<libpal.h>"
+                        "<libpal.h>",
+                        "<string.h>", # for memset
                     ])
 
                 outfile_path = os.path.join(outpath, reg.name.lower() + ".h")

--- a/pal/generator/cxx_header_generator.py
+++ b/pal/generator/cxx_header_generator.py
@@ -38,7 +38,8 @@ class CxxHeaderGenerator(AbstractGenerator):
 
                 if config.access_mechanism == "libpal":
                     self.gadgets["pal.header_depends"].includes.extend([
-                        "<libpal.h>"
+                        "<libpal.h>",
+                        "<string.h>", # for memset
                     ])
 
                 outfile_path = os.path.join(outpath, reg.name.lower() + ".h")


### PR DESCRIPTION
Add missing #include <string.h> since memset is needed by code generated
for the libpal access mechansim. Also, fix C builds by guarding the
extern "C" with #ifdef __cplusplus. Finally, make sure libpal.h is
public and can be included by dependents.