### PR TITLE
libpal: implement remaining access mechanisms

### DIFF
--- a/data/x86_64/register/control_register/cr1.yml
+++ b/data/x86_64/register/control_register/cr1.yml
@@ -6,14 +6,9 @@
       "
   size: 64
   arch: x86_64
-  
+
   access_mechanisms:
-      - name: mov_read
-        source_mnemonic: cr1
-
-      - name: mov_write
-        destination_mnemonic: cr1
-
+  
   fieldsets:
       - name: latest
         condition: "Fieldset valid on latest version of the Intel architecture"

--- a/libpal/CMakeLists.txt
+++ b/libpal/CMakeLists.txt
@@ -5,6 +5,7 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
 	    cpuid_x64.asm
 	    rdmsr_x64.asm
 	    vmread_x64.asm
+	    control_registers_x64.asm
     )
     set_target_properties(libpal PROPERTIES OUTPUT_NAME pal)
     target_include_directories(libpal PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/libpal/CMakeLists.txt
+++ b/libpal/CMakeLists.txt
@@ -2,6 +2,7 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
     enable_language(ASM_MASM)
 
     add_library(libpal 
+	    control_registers_x64.asm
 	    cpuid_x64.asm
 	    rdmsr_x64.asm
 	    vmread_x64.asm

--- a/libpal/CMakeLists.txt
+++ b/libpal/CMakeLists.txt
@@ -8,6 +8,7 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
 	    rdmsr_x64.asm
 	    vmread_x64.asm
 	    vmwrite_x64.asm
+	    wrmsr_x64.asm
     )
     set_target_properties(libpal PROPERTIES OUTPUT_NAME pal)
     target_include_directories(libpal PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/libpal/CMakeLists.txt
+++ b/libpal/CMakeLists.txt
@@ -1,7 +1,10 @@
 if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
     enable_language(ASM_MASM)
 
-    add_library(libpal cpuid_x64.asm)
+    add_library(libpal 
+	    cpuid_x64.asm
+	    rdmsr_x64.asm
+    )
     set_target_properties(libpal PROPERTIES OUTPUT_NAME pal)
     target_include_directories(libpal PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 endif()

--- a/libpal/CMakeLists.txt
+++ b/libpal/CMakeLists.txt
@@ -7,7 +7,7 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
 	    extended_control_registers_x64.asm
 	    rdmsr_x64.asm
 	    vmread_x64.asm
-	    control_registers_x64.asm
+	    vmwrite_x64.asm
     )
     set_target_properties(libpal PROPERTIES OUTPUT_NAME pal)
     target_include_directories(libpal PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/libpal/CMakeLists.txt
+++ b/libpal/CMakeLists.txt
@@ -4,6 +4,7 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
     add_library(libpal 
 	    control_registers_x64.asm
 	    cpuid_x64.asm
+	    extended_control_registers_x64.asm
 	    rdmsr_x64.asm
 	    vmread_x64.asm
 	    control_registers_x64.asm

--- a/libpal/CMakeLists.txt
+++ b/libpal/CMakeLists.txt
@@ -4,6 +4,7 @@ if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
     add_library(libpal 
 	    cpuid_x64.asm
 	    rdmsr_x64.asm
+	    vmread_x64.asm
     )
     set_target_properties(libpal PROPERTIES OUTPUT_NAME pal)
     target_include_directories(libpal PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/libpal/control_registers_x64.asm
+++ b/libpal/control_registers_x64.asm
@@ -1,0 +1,28 @@
+.code
+
+pal_execute_cr0_read proc
+    mov rax, cr0;
+    ret;
+pal_execute_cr0_read endp
+
+pal_execute_cr2_read proc
+    mov rax, cr2;
+    ret;
+pal_execute_cr2_read endp
+
+pal_execute_cr3_read proc
+    mov rax, cr3;
+    ret;
+pal_execute_cr3_read endp
+
+pal_execute_cr4_read proc
+    mov rax, cr4;
+    ret;
+pal_execute_cr4_read endp
+
+pal_execute_cr8_read proc
+    mov rax, cr8;
+    ret;
+pal_execute_cr8_read endp
+
+end

--- a/libpal/control_registers_x64.asm
+++ b/libpal/control_registers_x64.asm
@@ -25,4 +25,29 @@ pal_execute_cr8_read proc
     ret;
 pal_execute_cr8_read endp
 
+pal_execute_cr0_write proc
+    mov cr0, rcx;
+    ret;
+pal_execute_cr0_write endp
+
+pal_execute_cr2_write proc
+    mov cr2, rcx;
+    ret;
+pal_execute_cr2_write endp
+
+pal_execute_cr3_write proc
+    mov cr3, rcx;
+    ret;
+pal_execute_cr3_write endp
+
+pal_execute_cr4_write proc
+    mov cr4, rcx;
+    ret;
+pal_execute_cr4_write endp
+
+pal_execute_cr8_write proc
+    mov cr8, rcx;
+    ret;
+pal_execute_cr8_write endp
+
 end

--- a/libpal/extended_control_registers_x64.asm
+++ b/libpal/extended_control_registers_x64.asm
@@ -14,4 +14,16 @@ pal_execute_xgetbv proc
 
 pal_execute_xgetbv endp
 
+pal_execute_xsetbv proc
+    ; The address is already loaded in rcx because
+    ; it is the first integer argument. The value to
+    ; write is in rdx. We need that to be in edx:eax.
+    mov rax, rdx;
+    shr rdx, 032;
+    xsetbv;
+
+    ret;
+
+pal_execute_xsetbv endp
+
 end

--- a/libpal/extended_control_registers_x64.asm
+++ b/libpal/extended_control_registers_x64.asm
@@ -1,0 +1,17 @@
+.code
+
+pal_execute_xgetbv proc
+    ; The argument to pass to xgetbv via ecx is already
+    ; there, since it is the first integer passed here.
+    xgetbv;
+
+    ; The result is stored in edx:eax, so get it into rax
+    ; and return.
+    shl rdx, 032;
+    or rax, rdx;
+
+    ret;
+
+pal_execute_xgetbv endp
+
+end

--- a/libpal/libpal.h
+++ b/libpal/libpal.h
@@ -58,6 +58,16 @@ uint64_t pal_execute_cr4_read();
 
 uint64_t pal_execute_cr8_read();
 
+void pal_execute_cr0_write(uint64_t value);
+
+void pal_execute_cr2_write(uint64_t value);
+
+void pal_execute_cr3_write(uint64_t value);
+
+void pal_execute_cr4_write(uint64_t value);
+
+void pal_execute_cr8_write(uint64_t value);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/libpal/libpal.h
+++ b/libpal/libpal.h
@@ -50,6 +50,8 @@ uint32_t pal_execute_vmread(uintptr_t addr);
 
 uint64_t pal_execute_xgetbv(uintptr_t reg);
 
+void pal_execute_xsetbv(uintptr_t reg, uint64_t value);
+
 uint64_t pal_execute_cr0_read();
 
 uint64_t pal_execute_cr2_read();

--- a/libpal/libpal.h
+++ b/libpal/libpal.h
@@ -34,19 +34,32 @@ typedef struct pal_cpuid_register_values {
     uint32_t edx;
 } pal_cpuid_register_values;
 
+/* 
+ * Make sure that extern functions build for
+ * C and C++ 
+*/
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
+
 pal_cpuid_register_values pal_execute_cpuid(uint32_t eax, uint32_t ecx);
 
-#ifdef __cplusplus
-extern "C"
-#endif
 uint64_t pal_execute_rdmsr(uintptr_t ecx);
 
-#ifdef __cplusplus
-extern "C"
-#endif
 uint32_t pal_execute_vmread(uintptr_t addr);
 
+uint64_t pal_execute_cr0_read();
+
+uint64_t pal_execute_cr2_read();
+
+uint64_t pal_execute_cr3_read();
+
+uint64_t pal_execute_cr4_read();
+
+uint64_t pal_execute_cr8_read();
+
+#ifdef __cplusplus
+} /* extern "C" */
 #endif
+
+#endif /* LIBPAL_H */

--- a/libpal/libpal.h
+++ b/libpal/libpal.h
@@ -46,6 +46,8 @@ pal_cpuid_register_values pal_execute_cpuid(uint32_t eax, uint32_t ecx);
 
 uint64_t pal_execute_rdmsr(uintptr_t ecx);
 
+void pal_execute_wrmsr(uintptr_t addr, uint64_t value);
+
 uint32_t pal_execute_vmread(uintptr_t addr);
 
 void pal_execute_vmwrite(uintptr_t addr, uint64_t value);

--- a/libpal/libpal.h
+++ b/libpal/libpal.h
@@ -39,4 +39,9 @@ extern "C"
 #endif
 pal_cpuid_register_values pal_execute_cpuid(uint32_t eax, uint32_t ecx);
 
+#ifdef __cplusplus
+extern "C"
+#endif
+uint64_t pal_execute_rdmsr(uintptr_t ecx);
+
 #endif

--- a/libpal/libpal.h
+++ b/libpal/libpal.h
@@ -48,6 +48,8 @@ uint64_t pal_execute_rdmsr(uintptr_t ecx);
 
 uint32_t pal_execute_vmread(uintptr_t addr);
 
+void pal_execute_vmwrite(uintptr_t addr, uint64_t value);
+
 uint64_t pal_execute_xgetbv(uintptr_t reg);
 
 void pal_execute_xsetbv(uintptr_t reg, uint64_t value);

--- a/libpal/libpal.h
+++ b/libpal/libpal.h
@@ -44,4 +44,9 @@ extern "C"
 #endif
 uint64_t pal_execute_rdmsr(uintptr_t ecx);
 
+#ifdef __cplusplus
+extern "C"
+#endif
+uint32_t pal_execute_vmread(uintptr_t addr);
+
 #endif

--- a/libpal/libpal.h
+++ b/libpal/libpal.h
@@ -48,6 +48,8 @@ uint64_t pal_execute_rdmsr(uintptr_t ecx);
 
 uint32_t pal_execute_vmread(uintptr_t addr);
 
+uint64_t pal_execute_xgetbv(uintptr_t reg);
+
 uint64_t pal_execute_cr0_read();
 
 uint64_t pal_execute_cr2_read();

--- a/libpal/rdmsr_x64.asm
+++ b/libpal/rdmsr_x64.asm
@@ -1,0 +1,17 @@
+.code
+
+pal_execute_rdmsr proc
+    ; The argument to pass to rdmsr via ecx is already
+    ; there, since it is the first integer passed here.
+    rdmsr;
+
+    ; The result is stored in edx:eax, so get it into rax
+    ; and return.
+    shl rdx, 032;
+    or rax, rdx;
+
+    ret;
+
+pal_execute_rdmsr endp
+
+end

--- a/libpal/vmread_x64.asm
+++ b/libpal/vmread_x64.asm
@@ -1,0 +1,11 @@
+.code
+
+pal_execute_vmread proc
+   ; The VMCS address was given in rcx
+   vmread rax, rcx;
+
+   ret;
+
+pal_execute_vmread endp
+
+end

--- a/libpal/vmwrite_x64.asm
+++ b/libpal/vmwrite_x64.asm
@@ -1,0 +1,8 @@
+.code
+
+pal_execute_vmwrite proc
+    vmwrite rdx, rcx;
+    ret;
+pal_execute_vmwrite endp
+
+end

--- a/libpal/wrmsr_x64.asm
+++ b/libpal/wrmsr_x64.asm
@@ -1,0 +1,15 @@
+.code
+
+pal_execute_wrmsr proc
+    ; The address is already loaded in rcx because
+    ; it is the first integer argument. The value to
+    ; write is in rdx. We need that to be in edx:eax.
+    mov rax, rdx;
+    shr rdx, 032;
+    wrmsr;
+
+    ret;
+
+pal_execute_wrmsr endp
+
+end

--- a/pal/writer/access_mechanism/libpal.py
+++ b/pal/writer/access_mechanism/libpal.py
@@ -11,6 +11,7 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
             'rdmsr': self.__call_rdmsr_access_mechanism,
             'vmread': self.__call_vmread_access_mechanism,
             'mov_read': self.__call_mov_read_access_mechanism,
+            'xgetbv': self.__call_xgetbv_read_access_mechanism,
         }
 
         if access_mechanism.name not in access_mechanisms:
@@ -87,4 +88,12 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
     def __call_mov_write_access_mechanism(self, outfile, register,
                                           access_mechanism, value):
         outfile.write('pal_execute_{}_write({});'.format(access_mechanism.destination_mnemonic, value))
+        self.write_newline(outfile)
+
+    def __call_xgetbv_read_access_mechanism(self, outfile, register,
+                                            access_mechanism, result):
+
+        self.write_newline(outfile)
+        outfile.write('{} = pal_execute_xgetbv({});'.format(result, hex(access_mechanism.register)))
+        self.write_newline(outfile)
         self.write_newline(outfile)

--- a/pal/writer/access_mechanism/libpal.py
+++ b/pal/writer/access_mechanism/libpal.py
@@ -10,6 +10,7 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
             'cpuid': self.__call_cpuid_access_mechanism,
             'rdmsr': self.__call_rdmsr_access_mechanism,
             'vmread': self.__call_vmread_access_mechanism,
+            'mov_read': self.__call_mov_read_access_mechanism,
         }
 
         if access_mechanism.name not in access_mechanisms:
@@ -71,5 +72,12 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
                                        access_mechanism, result):
         self.write_newline(outfile)
         outfile.write('{} = pal_execute_vmread({});'.format(result, hex(access_mechanism.encoding)))
+        self.write_newline(outfile)
+        self.write_newline(outfile)
+
+    def __call_mov_read_access_mechanism(self, outfile, register,
+                                         access_mechanism, result):
+        self.write_newline(outfile)
+        outfile.write('{} = pal_execute_{}_read();'.format(result, access_mechanism.source_mnemonic))
         self.write_newline(outfile)
         self.write_newline(outfile)

--- a/pal/writer/access_mechanism/libpal.py
+++ b/pal/writer/access_mechanism/libpal.py
@@ -28,6 +28,7 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
                                        access_mechanism, value):
         access_mechanisms = {
             'mov_write': self.__call_mov_write_access_mechanism,
+            'wrmsr': self.__call_wrmsr_access_mechanism,
             'vmwrite': self.__call_vmwrite_access_mechanism,
             'xsetbv': self.__call_xsetbv_access_mechansim,
         }
@@ -90,6 +91,11 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
     def __call_mov_write_access_mechanism(self, outfile, register,
                                           access_mechanism, value):
         outfile.write('pal_execute_{}_write({});'.format(access_mechanism.destination_mnemonic, value))
+        self.write_newline(outfile)
+
+    def __call_wrmsr_access_mechanism(self, outfile, register,
+                                      access_mechanism, value):
+        outfile.write('pal_execute_wrmsr({},{});'.format(hex(access_mechanism.address),value))
         self.write_newline(outfile)
 
     def __call_vmwrite_access_mechanism(self, outfile, register,

--- a/pal/writer/access_mechanism/libpal.py
+++ b/pal/writer/access_mechanism/libpal.py
@@ -25,7 +25,9 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
 
     def call_writable_access_mechanism(self, outfile, register,
                                        access_mechanism, value):
-        access_mechanisms = {}
+        access_mechanisms = {
+            'mov_write': self.__call_mov_write_access_mechanism,
+        }
 
         if access_mechanism.name not in access_mechanisms:
             msg = "Access mechnism {am} is not supported using libpal"
@@ -35,7 +37,7 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
             return
 
         access_mechanisms[access_mechanism.name](outfile,register,
-                                                 access_mechanism, result)
+                                                 access_mechanism, value)
 
     def __call_cpuid_access_mechanism(self, outfile, register,
                                       access_mechanism, result):
@@ -80,4 +82,9 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
         self.write_newline(outfile)
         outfile.write('{} = pal_execute_{}_read();'.format(result, access_mechanism.source_mnemonic))
         self.write_newline(outfile)
+        self.write_newline(outfile)
+
+    def __call_mov_write_access_mechanism(self, outfile, register,
+                                          access_mechanism, value):
+        outfile.write('pal_execute_{}_write({});'.format(access_mechanism.destination_mnemonic, value))
         self.write_newline(outfile)

--- a/pal/writer/access_mechanism/libpal.py
+++ b/pal/writer/access_mechanism/libpal.py
@@ -7,7 +7,8 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
     def call_readable_access_mechanism(self, outfile, register,
                                        access_mechanism, result):
         access_mechanisms = {
-            'cpuid': self.__call_cpuid_access_mechanism
+            'cpuid': self.__call_cpuid_access_mechanism,
+            'rdmsr': self.__call_rdmsr_access_mechanism,
         }
 
         if access_mechanism.name not in access_mechanisms:
@@ -57,3 +58,10 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
         self.write_newline(outfile);
 
         self.write_newline(outfile);
+
+    def __call_rdmsr_access_mechanism(self, outfile, reigster,
+                                      access_mechanism, result):
+        self.write_newline(outfile)
+        outfile.write('{} = pal_execute_rdmsr({});'.format(result, hex(access_mechanism.address)))
+        self.write_newline(outfile)
+        self.write_newline(outfile)

--- a/pal/writer/access_mechanism/libpal.py
+++ b/pal/writer/access_mechanism/libpal.py
@@ -28,6 +28,7 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
                                        access_mechanism, value):
         access_mechanisms = {
             'mov_write': self.__call_mov_write_access_mechanism,
+            'vmwrite': self.__call_vmwrite_access_mechanism,
             'xsetbv': self.__call_xsetbv_access_mechansim,
         }
 
@@ -89,6 +90,11 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
     def __call_mov_write_access_mechanism(self, outfile, register,
                                           access_mechanism, value):
         outfile.write('pal_execute_{}_write({});'.format(access_mechanism.destination_mnemonic, value))
+        self.write_newline(outfile)
+
+    def __call_vmwrite_access_mechanism(self, outfile, register,
+                                        access_mechanism, value):
+        outfile.write('pal_execute_vmwrite({},{});'.format(hex(access_mechanism.encoding), value))
         self.write_newline(outfile)
 
     def __call_xgetbv_read_access_mechanism(self, outfile, register,

--- a/pal/writer/access_mechanism/libpal.py
+++ b/pal/writer/access_mechanism/libpal.py
@@ -28,6 +28,7 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
                                        access_mechanism, value):
         access_mechanisms = {
             'mov_write': self.__call_mov_write_access_mechanism,
+            'xsetbv': self.__call_xsetbv_access_mechansim,
         }
 
         if access_mechanism.name not in access_mechanisms:
@@ -96,4 +97,9 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
         self.write_newline(outfile)
         outfile.write('{} = pal_execute_xgetbv({});'.format(result, hex(access_mechanism.register)))
         self.write_newline(outfile)
+        self.write_newline(outfile)
+
+    def __call_xsetbv_access_mechansim(self, outfile, register,
+                                       access_mechanism, value):
+        outfile.write('pal_execute_xsetbv({},{});'.format(hex(access_mechanism.register),value))
         self.write_newline(outfile)

--- a/pal/writer/access_mechanism/libpal.py
+++ b/pal/writer/access_mechanism/libpal.py
@@ -9,6 +9,7 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
         access_mechanisms = {
             'cpuid': self.__call_cpuid_access_mechanism,
             'rdmsr': self.__call_rdmsr_access_mechanism,
+            'vmread': self.__call_vmread_access_mechanism,
         }
 
         if access_mechanism.name not in access_mechanisms:
@@ -63,5 +64,12 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
                                       access_mechanism, result):
         self.write_newline(outfile)
         outfile.write('{} = pal_execute_rdmsr({});'.format(result, hex(access_mechanism.address)))
+        self.write_newline(outfile)
+        self.write_newline(outfile)
+
+    def __call_vmread_access_mechanism(self, outfile, register,
+                                       access_mechanism, result):
+        self.write_newline(outfile)
+        outfile.write('{} = pal_execute_vmread({});'.format(result, hex(access_mechanism.encoding)))
         self.write_newline(outfile)
         self.write_newline(outfile)


### PR DESCRIPTION
Implement remaining access mechanisms for libpal/MASM x64. I have only tested the builds, and done my best to verify correctness by comparing to existing access mechanism implementations (e.g. `gas_att`), but have not been able to exercise any of this code in a driver.

For review purposes, it will be worth figuring out if the strategy described [here](https://github.com/Bareflank/pal/commit/d2dd475396bced811a880e73418b66ef9ccdf5c1#diff-3a989a8e693d434940f4760ada29ae3dR55) for handling CR1 access makes sense. It appears this sort of thing has not been an issue before.