### PR TITLE
libpal: Swap registers given to vmwrite

### DIFF
--- a/libpal/vmwrite_x64.asm
+++ b/libpal/vmwrite_x64.asm
@@ -1,7 +1,7 @@
 .code
 
 pal_execute_vmwrite proc
-    vmwrite rdx, rcx;
+    vmwrite rcx, rdx;
     ret;
 pal_execute_vmwrite endp
 


### PR DESCRIPTION
The vmcs field is given in the left-most operand (what the manual calls
the "register secondary source operand") of vmwrite. Swap rcx and rdx to
reflect this.