### PR TITLE
cargo: Ensure that pal.py has succeeded

### DIFF
--- a/cargo/build.rs
+++ b/cargo/build.rs
@@ -31,7 +31,9 @@ fn generate_language_bindings() {
     let output = Command::new("./pal.py")
             .args(args)
             .output()
-            .expect("pal.py command failed");
+            .expect("failed to spawn pal.py");
+
+    assert!(output.status.success());
 
     let output_text = String::from_utf8(output.stdout).unwrap();
     println!("{}", output_text);
@@ -80,7 +82,9 @@ fn configure_cmake(cmake_build_dir: &str) {
     let output = Command::new("cmake")
             .args(args)
             .output()
-            .expect("cmake configure command failed");
+            .expect("failed to spawn cmake configure");
+
+    assert!(output.status.success());
 
     let output_text = String::from_utf8(output.stdout).unwrap();
     println!("{}", output_text);
@@ -91,7 +95,10 @@ fn run_cmake(cmake_build_dir: &str) {
             .arg("--build")
             .arg(cmake_build_dir)
             .output()
-            .expect("cmake build command failed");
+            .expect("failed to spawn cmake build");
+
+    assert!(output.status.success());
+
     let output_text = String::from_utf8(output.stdout).unwrap();
     println!("{}", output_text);
 }


### PR DESCRIPTION
Ok() from Command::output only indicates that the process has been successfully spawned and has exited.