### PR TITLE
cargo: Add no_std support

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -30,3 +30,7 @@ jobs:
     - name: Build
       shell: bash
       run: cargo build --manifest-path test/rust/intel/Cargo.toml
+
+    - name: Build (no_std)
+      shell: bash
+      run: cargo build --manifest-path test/rust/intel/Cargo.toml --no-default-features --features nasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,14 @@ path = "cargo/lib.rs"
 
 [dependencies]
 cty = "0.2.1"
-term = "0.7.0"
+term = { version = "0.7.0", optional = true }
 
 [build-dependencies]
 pkg-config = "0.3.16"
 
 [features]
-intel_64bit_linux_ioctl = []
+std = []
+enable_printers = ["term"]
+
+intel_64bit_linux_ioctl = ["std", "enable_printers"]
 intel_64bit_systemv_nasm = []

--- a/cargo/build.rs
+++ b/cargo/build.rs
@@ -24,7 +24,7 @@ fn generate_language_bindings() {
     }
 
     // TODO: Add support for print functions in a no_std environment
-    if cfg!(feature = "intel_64bit_systemv_nasm") {
+    if cfg!(not(feature = "enable_printers")) {
         args.push("--enable_printers=off");
     }
 

--- a/cargo/lib.rs
+++ b/cargo/lib.rs
@@ -1,1 +1,2 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 include!(concat!(env!("OUT_DIR"), "/src/lib.rs"));

--- a/test/rust/intel/Cargo.toml
+++ b/test/rust/intel/Cargo.toml
@@ -6,4 +6,9 @@ edition = "2018"
 
 [dependencies.pal]
 path = "../../../"
-features = ["intel_64bit_linux_ioctl"]
+default-features = false
+
+[features]
+default = ["std"]
+std = ["pal/std", "pal/intel_64bit_linux_ioctl"]
+nasm = ["pal/intel_64bit_systemv_nasm"]

--- a/test/rust/intel/src/cpuid.rs
+++ b/test/rust/intel/src/cpuid.rs
@@ -7,8 +7,14 @@ pub fn test_cpuid_compile()
 
     let (eax, ebx, ecx, edx) = pal::instruction::execute_cpuid(leaf, subleaf);
 
+    #[cfg(feature = "pal/enable_printers")]
+    {
     pal::cpuid::leaf_01_eax::print_from_value(eax);
     pal::cpuid::leaf_01_ebx::print_from_value(ebx);
     pal::cpuid::leaf_01_ecx::print_from_value(ecx);
     pal::cpuid::leaf_01_edx::print_from_value(edx);
+    }
+
+    #[cfg(not(feature = "pal/enable_printers"))]
+    let _ = (eax, ebx, ecx, edx);
 }

--- a/test/rust/intel/src/cr3.rs
+++ b/test/rust/intel/src/cr3.rs
@@ -20,6 +20,8 @@ pub fn test_cr3_compile()
     pal::control_register::cr3::set_page_directory_base(0x0);
     pal::control_register::cr3::set_page_directory_base_in_value(0x0, &mut value);
 
+    #[cfg(feature = "pal/enable_printers")]
+    {
     // Printers
     pal::control_register::cr3::print();
     pal::control_register::cr3::print_from_value(value);
@@ -27,4 +29,5 @@ pub fn test_cr3_compile()
     pal::control_register::cr3::print_pcd_from_value(value);
     pal::control_register::cr3::print_page_directory_base();
     pal::control_register::cr3::print_page_directory_base_from_value(value);
+    }
 }

--- a/test/rust/intel/src/eptp.rs
+++ b/test/rust/intel/src/eptp.rs
@@ -20,6 +20,8 @@ pub fn test_eptp_compile()
     pal::vmcs::eptp::set_ept_pml4_table(0x0);
     pal::vmcs::eptp::set_ept_pml4_table_in_value(0x0, &mut value);
 
+    #[cfg(feature = "pal/enable_printers")]
+    {
     // Printers
     pal::vmcs::eptp::print();
     pal::vmcs::eptp::print_from_value(value);
@@ -27,4 +29,5 @@ pub fn test_eptp_compile()
     pal::vmcs::eptp::print_bit_6_from_value(value);
     pal::vmcs::eptp::print_ept_pml4_table();
     pal::vmcs::eptp::print_ept_pml4_table_from_value(value);
+    }
 }

--- a/test/rust/intel/src/guest_interrupt_status.rs
+++ b/test/rust/intel/src/guest_interrupt_status.rs
@@ -12,9 +12,12 @@ pub fn test_guest_interrupt_status_compile()
     pal::vmcs::guest_interrupt_status::set_rvi(0x0);
     pal::vmcs::guest_interrupt_status::set_rvi_in_value(0x0, &mut value);
 
+    #[cfg(feature = "pal/enable_printers")]
+    {
     // Printers
     pal::vmcs::guest_interrupt_status::print();
     pal::vmcs::guest_interrupt_status::print_from_value(value);
     pal::vmcs::guest_interrupt_status::print_rvi();
     pal::vmcs::guest_interrupt_status::print_rvi_from_value(value);
+    }
 }

--- a/test/rust/intel/src/ia32_feature_control.rs
+++ b/test/rust/intel/src/ia32_feature_control.rs
@@ -20,6 +20,8 @@ pub fn test_ia32_feature_control_compile()
     pal::msr::ia32_feature_control::set_senter_local_function_enable(0x0);
     pal::msr::ia32_feature_control::set_senter_local_function_enable_in_value(0x0, &mut value);
 
+    #[cfg(feature = "pal/enable_printers")]
+    {
     // Printers
     pal::msr::ia32_feature_control::print();
     pal::msr::ia32_feature_control::print_from_value(value);
@@ -27,4 +29,5 @@ pub fn test_ia32_feature_control_compile()
     pal::msr::ia32_feature_control::print_enable_vmx_inside_smx_from_value(value);
     pal::msr::ia32_feature_control::print_senter_local_function_enable();
     pal::msr::ia32_feature_control::print_senter_local_function_enable_from_value(value);
+    }
 }

--- a/test/rust/intel/src/leaf_01.rs
+++ b/test/rust/intel/src/leaf_01.rs
@@ -10,8 +10,11 @@ pub fn test_leaf_01_compile()
     let _value = pal::cpuid::leaf_01_eax::get_model();
     let _value2 = pal::cpuid::leaf_01_eax::get_model_from_value(eax);
 
+    #[cfg(feature = "pal/enable_printers")]
+    {
     pal::cpuid::leaf_01_eax::print();
     pal::cpuid::leaf_01_eax::print_from_value(eax);
     pal::cpuid::leaf_01_eax::print_model();
     pal::cpuid::leaf_01_eax::print_model_from_value(eax);
+    }
 }

--- a/test/rust/intel/src/leaf_04.rs
+++ b/test/rust/intel/src/leaf_04.rs
@@ -14,10 +14,13 @@ pub fn test_leaf_04_compile()
     pal::cpuid::leaf_04_eax::get_cache_type_at_index(1);
     pal::cpuid::leaf_04_eax::get_cache_type_from_value(eax);
 
+    #[cfg(feature = "pal/enable_printers")]
+    {
     pal::cpuid::leaf_04_eax::print_at_index(1);
     pal::cpuid::leaf_04_eax::print_from_value(eax);
     pal::cpuid::leaf_04_eax::print_self_initializing_cache_level_at_index(1);
     pal::cpuid::leaf_04_eax::print_self_initializing_cache_level_from_value(eax);
     pal::cpuid::leaf_04_eax::print_cache_type_at_index(1);
     pal::cpuid::leaf_04_eax::print_cache_type_from_value(eax);
+    }
 }

--- a/test/rust/intel/src/leaf_0d.rs
+++ b/test/rust/intel/src/leaf_0d.rs
@@ -14,10 +14,13 @@ pub fn test_leaf_0d_compile()
     pal::cpuid::leaf_0d_eax::get_subleaf_0_mpx_state_at_index(1);
     pal::cpuid::leaf_0d_eax::get_subleaf_0_mpx_state_from_value(eax);
 
+    #[cfg(feature = "pal/enable_printers")]
+    {
     pal::cpuid::leaf_0d_eax::print_subleaf_0_at_index(1);
     pal::cpuid::leaf_0d_eax::print_subleaf_0_from_value(eax);
     pal::cpuid::leaf_0d_eax::print_subleaf_0_sse_state_at_index(1);
     pal::cpuid::leaf_0d_eax::print_subleaf_0_sse_state_from_value(eax);
     pal::cpuid::leaf_0d_eax::print_subleaf_0_mpx_state_at_index(1);
     pal::cpuid::leaf_0d_eax::print_subleaf_0_mpx_state_from_value(eax);
+    }
 }

--- a/test/rust/intel/src/main.rs
+++ b/test/rust/intel/src/main.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(not(feature = "std"),
+    no_std,
+    feature(lang_items, start),
+)]
+
 mod cpuid;
 mod cr3;
 mod eptp;
@@ -25,4 +30,33 @@ fn main() {
     read_cr3::test_read_cr3_compile();
     write_cr3::test_write_cr3_compile();
     xcr0::test_xcr0_compile();
+}
+
+#[cfg(not(feature = "std"))]
+#[start]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    main();
+    0
+}
+
+#[cfg(not(feature = "std"))]
+#[no_mangle]
+fn __libc_csu_init() {}
+
+#[cfg(not(feature = "std"))]
+#[no_mangle]
+fn __libc_csu_fini() {}
+
+#[cfg(not(feature = "std"))]
+#[no_mangle]
+fn __libc_start_main() {}
+
+#[cfg(not(feature = "std"))]
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[cfg(not(feature = "std"))]
+#[panic_handler]
+fn panic(_panic: &core::panic::PanicInfo<'_>) -> ! {
+    loop {}
 }

--- a/test/rust/intel/src/rdmsr.rs
+++ b/test/rust/intel/src/rdmsr.rs
@@ -4,5 +4,10 @@ pub fn test_rdmsr_compile()
 {
     let address = pal::msr::ia32_feature_control::ADDRESS;
     let value = pal::instruction::execute_rdmsr(address);
+
+    #[cfg(feature = "pal/enable_printers")]
     pal::msr::ia32_feature_control::print_from_value(value);
+
+    #[cfg(not(feature = "pal/enable_printers"))]
+    let _ = value;
 }

--- a/test/rust/intel/src/read_cr3.rs
+++ b/test/rust/intel/src/read_cr3.rs
@@ -3,5 +3,10 @@ use pal;
 pub fn test_read_cr3_compile()
 {
     let value = pal::instruction::execute_read_cr3();
+
+    #[cfg(feature = "pal/enable_printers")]
     pal::control_register::cr3::print_from_value(value);
+
+    #[cfg(not(feature = "pal/enable_printers"))]
+    let _ = value;
 }

--- a/test/rust/intel/src/xcr0.rs
+++ b/test/rust/intel/src/xcr0.rs
@@ -16,9 +16,12 @@ pub fn test_xcr0_compile()
     pal::control_register::xcr0::sse_is_disabled();
     pal::control_register::xcr0::sse_is_disabled_in_value(value);
 
+    #[cfg(feature = "pal/enable_printers")]
+    {
     // Printers
     pal::control_register::xcr0::print();
     pal::control_register::xcr0::print_from_value(value);
     pal::control_register::xcr0::print_sse();
     pal::control_register::xcr0::print_sse_from_value(value);
+    }
 }


### PR DESCRIPTION
The `term` dependency is now pulled in conditionally. A new job is also added to CI so the no_std version is tested.