### PR TITLE
intel_64bit_systemv_nasm: Fix vmread

### DIFF
--- a/libpal/intel_64bit_systemv_nasm/vmread.asm
+++ b/libpal/intel_64bit_systemv_nasm/vmread.asm
@@ -5,5 +5,5 @@ section .text
 
 global pal_execute_vmread 
 pal_execute_vmread :
-    vmread [rsi], rdi
+    vmread rax, rdi
     ret


### PR DESCRIPTION
The C signature is `uint64_t pal_execute_vmread(uint64_t encoding)`.

Looks like build-only tests are not enough. Bochs supports VMX emulation so we may be able to plug that into CI (GitHub Actions does not support nested virtualization).