### PR TITLE
cmake: Fail if python modules are missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/init_project.cmake)
 
 set(PYTHONPATH ${CMAKE_CURRENT_LIST_DIR})
 
+# check if the environment has these python modules
+pal_find_python_module(lxml)
+pal_find_python_module(dataclasses)
+pal_find_python_module(colorama)
+pal_find_python_module(yaml)
+
 if(PAL_ARMV8A_AARCH32_AAPCS_GNU)
     if(PAL_C)
         pal_run_generator(
@@ -204,5 +210,8 @@ endif()
 
 if(NOT PAL_QUIET_CMAKE)
     pal_print_banner()
+endif()
+
+if (NOT PAL_QUIET_CMAKE AND NOT PYTHON_MODULES_MISSING)
     pal_print_usage()
 endif()

--- a/cmake/macros/macros.cmake
+++ b/cmake/macros/macros.cmake
@@ -1,5 +1,6 @@
 include(${CMAKE_CURRENT_LIST_DIR}/pal_add_config.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/pal_add_compilation_test.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/pal_find_python_module.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/pal_print_banner.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/pal_print_usage.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/pal_run_generator.cmake)

--- a/cmake/macros/pal_find_python_module.cmake
+++ b/cmake/macros/pal_find_python_module.cmake
@@ -1,0 +1,15 @@
+function(pal_find_python_module module)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -c "import ${module}"
+        RESULT_VARIABLE PY_EXIT_STATUS
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    if (NOT ${PY_EXIT_STATUS} EQUAL 0)
+        message(
+            SEND_ERROR
+            "The ${Yellow} ${module} ${ColorReset} Python3 package is ${BoldRed} not found! ${ColorReset}"
+        )
+	set(PYTHON_MODULES_MISSING TRUE PARENT_SCOPE)
+    endif()
+endfunction(pal_find_python_module)


### PR DESCRIPTION
Adds a check for python module dependencies. Let's fail early!
Also, do not announce "success" if dependencies are missing.

Ideally, we would want to have a `shell.nix` that pulls in all the dependencies. 
