### PR TITLE
rust: Generate documentations

### DIFF
--- a/cargo/build.rs
+++ b/cargo/build.rs
@@ -28,15 +28,12 @@ fn generate_language_bindings() {
         args.push("--enable_printers=off");
     }
 
-    let output = Command::new("./pal.py")
+    let status = Command::new("./pal.py")
             .args(args)
-            .output()
+            .status()
             .expect("failed to spawn pal.py");
 
-    assert!(output.status.success());
-
-    let output_text = String::from_utf8(output.stdout).unwrap();
-    println!("{}", output_text);
+    assert!(status.success());
 }
 
 fn build_libpal() {
@@ -79,26 +76,20 @@ fn configure_cmake(cmake_build_dir: &str) {
         args.push("-DPAL_INTEL_64BIT_SYSTEMV_NASM=ON");
     }
 
-    let output = Command::new("cmake")
+    let status = Command::new("cmake")
             .args(args)
-            .output()
+            .status()
             .expect("failed to spawn cmake configure");
 
-    assert!(output.status.success());
-
-    let output_text = String::from_utf8(output.stdout).unwrap();
-    println!("{}", output_text);
+    assert!(status.success());
 }
 
 fn run_cmake(cmake_build_dir: &str) {
-    let output = Command::new("cmake")
+    let status = Command::new("cmake")
             .arg("--build")
             .arg(cmake_build_dir)
-            .output()
+            .status()
             .expect("failed to spawn cmake build");
 
-    assert!(output.status.success());
-
-    let output_text = String::from_utf8(output.stdout).unwrap();
-    println!("{}", output_text);
+    assert!(status.success());
 }

--- a/pal/gadget/rust/function_definition.py
+++ b/pal/gadget/rust/function_definition.py
@@ -18,6 +18,9 @@ class properties(GadgetProperties):
         field(default_factory= lambda: [])
     """ List of argmuent type/name tuples for the generated function """
 
+    documentation: dict = None
+    """ Documentation for the generated function """
+
     return_type: str = None
     """ Return type for the generated function """
 
@@ -36,12 +39,19 @@ def function_definition(decorated):
         properties.name = "my_function"
         properties.return_type = "u64"
         properties.args = [("u64", "arg1")]
+        properties.documentation = {
+            'summary': 'Short summary of the function.',
+            'details': 'And here are the details',
+        }
 
         @function_definition
         function(generator, outfile, ...):
             outfile.write("contents inside function body")
 
     Generates:
+        /// Short summary of the function.
+        ///
+        /// And here are the details.
         pub fn my_function(arg1: u64) -> u64 {
             contents inside function body
         }
@@ -50,7 +60,9 @@ def function_definition(decorated):
         properties = generator.gadgets["pal.rust.function_definition"]
         writer = generator.get_writer()
 
-        writer.write_indent(outfile, count=properties.indent)
+        if properties.documentation:
+            doc = properties.documentation
+            writer.declare_item_documentation(outfile, doc["summary"], 75, details=doc["details"])
 
         if properties.pub == True:
             outfile.write("pub ")

--- a/pal/generator/rust_generator.py
+++ b/pal/generator/rust_generator.py
@@ -67,6 +67,7 @@ class RustGenerator(AbstractGenerator):
             raise PalGeneratorException(msg)
 
     def _generate_register(self, outfile, reg):
+        self._generate_register_documentation(outfile, reg)
 
         self.writer.declare_register_dependencies(outfile, reg, self.config)
 
@@ -79,7 +80,6 @@ class RustGenerator(AbstractGenerator):
 
         self.writer.write_newline(outfile)
 
-        self._generate_register_comment(outfile, reg)
         self.writer.declare_register_accessors(outfile, reg)
 
         for idx, fieldset in enumerate(reg.fieldsets):
@@ -99,14 +99,10 @@ class RustGenerator(AbstractGenerator):
         self.writer.declare_instruction_accessor(outfile, inst)
         self.writer.write_newline(outfile)
 
-    def _generate_register_comment(self, outfile, reg):
-        comment = "{name} ({long_name}){separator}{purpose}".format(
-            name=str(reg.name),
-            long_name=str(reg.long_name),
-            separator=" - " if reg.purpose else "",
-            purpose=str(reg.purpose)
-        )
-        self.writer.declare_comment(outfile, comment, 75)
+    def _generate_register_documentation(self, outfile, reg):
+        summary = str(reg.long_name) + "."
+
+        self.writer.declare_file_documentation(outfile, summary, 75, details=str(reg.purpose))
 
     def __update_module_files(self, outpath):
         modfile_path = os.path.join(outpath, "mod.rs")

--- a/pal/parser/pal_model_parser.py
+++ b/pal/parser/pal_model_parser.py
@@ -12,6 +12,7 @@ import pal.model.intel.access_mechanism
 from yaml import load, dump
 from yaml import CLoader as Loader, CDumper as Dumper
 
+import re
 
 class PalModelParser(AbstractParser):
     def parse_file(self, path):
@@ -55,7 +56,7 @@ class PalModelParser(AbstractParser):
         if "long_name" in yml:
             register.long_name = self._strip_string(yml["long_name"])
         if "purpose" in yml:
-            register.purpose = self._strip_string(yml["purpose"])
+            register.purpose = self._reflow_text(yml["purpose"])
         if "arch" in yml:
             register.arch = self._strip_string(yml["arch"])
         if "is_internal" in yml:
@@ -280,7 +281,7 @@ class PalModelParser(AbstractParser):
                 if "long_name" in field_yml:
                     field.long_name = self._strip_string(field_yml["long_name"])
                 if "description" in field_yml:
-                    field.description = self._strip_string(field_yml["description"])
+                    field.description = self._reflow_text(field_yml["description"])
                 if "readable" in field_yml:
                     field.readable = field_yml["readable"]
                 if "writable" in field_yml:
@@ -301,6 +302,10 @@ class PalModelParser(AbstractParser):
                 fs.fields.append(field)
 
             register.fieldsets.append(fs)
+
+    def _reflow_text(self, text):
+        text = re.sub(r"\r?\n\s*", " ", text.strip())
+        return re.sub(r"^\"\s*|\s*\"$", "", text)
 
     def _strip_string(self, string):
         if string.startswith("\""):

--- a/pal/writer/comment/c_multiline.py
+++ b/pal/writer/comment/c_multiline.py
@@ -15,3 +15,9 @@ class CMultilineCommentWriter(CommentWriter):
             self.write_newline(outfile)
         outfile.write("*/")
         self.write_newline(outfile)
+
+    def declare_file_documentation(self, outfile, summary, wrap, details=""):
+        pass
+
+    def declare_item_documentation(self, outfile, summary, wrap, details=""):
+        pass

--- a/pal/writer/comment/comment.py
+++ b/pal/writer/comment/comment.py
@@ -7,3 +7,11 @@ class CommentWriter(abc.ABC):
     @abc.abstractmethod
     def declare_comment(self, outfile: TextIO, comment: str, wrap: int) -> None:
         pass
+
+    @abc.abstractmethod
+    def declare_file_documentation(self, outfile: TextIO, summary: str, wrap: int, details: str="") -> None:
+        pass
+
+    @abc.abstractmethod
+    def declare_item_documentation(self, outfile: TextIO, summary: str, wrap: int, details: str="") -> None:
+        pass

--- a/pal/writer/comment/none.py
+++ b/pal/writer/comment/none.py
@@ -5,3 +5,9 @@ class NoneCommentWriter(CommentWriter):
 
     def declare_comment(self, outfile, comment, wrap):
         pass
+
+    def declare_file_documentation(self, outfile, summary, wrap, details=""):
+        pass
+
+    def declare_item_documentation(self, outfile, summary, wrap, details=""):
+        pass

--- a/pal/writer/comment/rust.py
+++ b/pal/writer/comment/rust.py
@@ -10,3 +10,36 @@ class RustCommentWriter(CommentWriter):
         for line in wrapped:
             outfile.write("// " + str(line))
             self.write_newline(outfile)
+
+    def declare_file_documentation(self, outfile, summary, wrap, details=""):
+        self._declare_documentation(outfile, "//!", summary, details, wrap)
+
+    def declare_item_documentation(self, outfile, summary, wrap, details=""):
+        self._declare_documentation(outfile, "///", summary, details, wrap)
+
+    def _declare_documentation(self, outfile, prefix, summary, details, wrap):
+        # Never wrap the summary
+        summary = self._escape_docstring(str(summary))
+        outfile.write(str(prefix) + " " + str(summary))
+        self.write_newline(outfile)
+
+        if str(details):
+            outfile.write(str(prefix))
+            self.write_newline(outfile)
+
+            wrapped = textwrap.wrap(
+                self._escape_docstring(str(details)),
+                width=(wrap - len(str(prefix)))
+            )
+
+            for line in wrapped:
+                outfile.write(prefix + " " + line)
+                self.write_newline(outfile)
+
+    def _escape_docstring(self, text):
+        need_escaping = ['[', ']']
+
+        for ch in need_escaping:
+            text = text.replace(ch, "\\" + ch)
+
+        return text

--- a/pal/writer/comment/yaml.py
+++ b/pal/writer/comment/yaml.py
@@ -10,3 +10,9 @@ class YamlCommentWriter(CommentWriter):
         for line in wrapped:
             outfile.write("# " + str(line))
             self.write_newline(outfile)
+
+    def declare_file_documentation(self, outfile, summary, wrap, details=""):
+        pass
+
+    def declare_item_documentation(self, outfile, summary, wrap, details=""):
+        pass

--- a/pal/writer/register/rust/field_accessor.py
+++ b/pal/writer/register/rust/field_accessor.py
@@ -83,6 +83,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = "bool"
         gadget.args = []
         gadget.name = self._bitfield_is_enabled_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Returns whether "{friendly_name}" is currently enabled.'
+        )
 
         if register.is_indexed:
             gadget.args.append(("usize", "index"))
@@ -111,6 +114,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = "bool"
         gadget.args = [(size_type, "value")]
         gadget.name = self._bitfield_is_enabled_in_value_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Returns whether "{friendly_name}" is enabled in the given register value.'
+        )
 
         self._declare_bitfield_is_enabled_in_val_details(outfile, register, field)
 
@@ -129,6 +135,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = "bool"
         gadget.args = []
         gadget.name = self._bitfield_is_disabled_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Returns whether "{friendly_name}" is currently disabled.'
+        )
 
         if register.is_indexed:
             gadget.args.append(("usize", "index"))
@@ -157,6 +166,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = "bool"
         gadget.args = [(size_type, "value")]
         gadget.name = self._bitfield_is_disabled_in_value_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Returns whether "{friendly_name}" is disabled in the given register value.'
+        )
 
         self._declare_bitfield_is_disabled_in_value_details(outfile, register, field)
 
@@ -173,6 +185,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = None
         gadget.args = []
         gadget.name = self._bitfield_enable_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Enables "{friendly_name}".'
+        )
 
         if register.is_indexed:
             gadget.args.append(("usize", "index"))
@@ -203,6 +218,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = None
         gadget.args = [(size_type, "value")]
         gadget.name = self._bitfield_enable_in_value_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Enables "{friendly_name}" in the given register value, returning the new value.'
+        )
 
         self._declare_bitfield_enable_in_value_details(outfile, register, field)
 
@@ -218,6 +236,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = None
         gadget.args = []
         gadget.name = self._bitfield_disable_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Disables "{friendly_name}".'
+        )
 
         if register.is_indexed:
             gadget.args.append(("usize", "index"))
@@ -248,6 +269,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = None
         gadget.args = [(size_type, "value")]
         gadget.name = self._bitfield_disable_in_value_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Disables "{friendly_name}" in the given register value, returning the new value.'
+        )
 
         self._declare_bitfield_disable_in_value_details(outfile, register, field)
 
@@ -265,6 +289,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = size_type
         gadget.args = []
         gadget.name = self._field_read_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Returns the current value of "{friendly_name}".'
+        )
 
         if register.is_indexed:
             gadget.args.append(("usize", "index"))
@@ -294,6 +321,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = size_type
         gadget.args = [(size_type, "value")]
         gadget.name = self._field_read_from_value_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Returns the value of "{friendly_name}" in the given register value.'
+        )
 
         self._declare_get_field_from_value_details(outfile, register, field)
 
@@ -314,6 +344,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = None
         gadget.args = [(size_type, "value")]
         gadget.name = self._field_write_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Sets the value of "{friendly_name}".'
+        )
 
         if register.is_indexed:
             gadget.args.append(("usize", "index"))
@@ -357,6 +390,9 @@ class RustFieldAccessorWriter():
         gadget.return_type = None
         gadget.args = [(size_type, "field_value"), (mutable_size_type, "register_value")]
         gadget.name = self._field_write_in_value_function_name(register, field)
+        gadget.documentation = self._field_documentation(register, field,
+            'Sets the value of "{friendly_name}" in the given register value, returning the new value.'
+        )
 
         self._declare_set_field_in_value_details(outfile, register, field)
 

--- a/pal/writer/register/rust/helper.py
+++ b/pal/writer/register/rust/helper.py
@@ -78,6 +78,14 @@ class RustHelperWriter():
             at_index="_at_index" if register.is_indexed else ""
         )
 
+    def _register_documentation(self, register, summary):
+        doc = {
+            "summary": summary.format(friendly_name=str(register.long_name)),
+            "details": register.purpose,
+        }
+
+        return doc
+
     def _bitfield_enable_function_name(self, register, field):
         return "enable_{field_name}{at_index}".format(
             field_name=field.name.lower(),
@@ -154,6 +162,14 @@ class RustHelperWriter():
         return "print_{field_name}_from_value".format(
             field_name=field.name.lower()
         )
+
+    def _field_documentation(self, register, field, summary):
+        doc = {
+            "summary": summary.format(friendly_name=str(field.long_name)),
+            "details": field.description,
+        }
+
+        return doc
 
     def _fieldset_print_function_name(self, register, fieldset):
         return "print{fieldset_name}{at_index}".format(

--- a/pal/writer/register/rust/register_accessor.py
+++ b/pal/writer/register/rust/register_accessor.py
@@ -71,6 +71,7 @@ class RustRegisterAccessorWriter():
         gadget.name = self._register_read_function_name(register)
         gadget.return_type = self._register_size_type(register)
         gadget.args = []
+        gadget.documentation = self._register_documentation(register, "Returns the current value of the register.")
 
         if register.is_indexed:
             gadget.args.append(("usize", "index"))
@@ -96,6 +97,7 @@ class RustRegisterAccessorWriter():
         gadget.name = self._register_write_function_name(register)
         gadget.return_type = None
         gadget.args = [(size_type, "value")]
+        gadget.documentation = self._register_documentation(register, "Sets the value of the register.")
 
         if register.is_indexed:
             gadget.args.append(("usize", "index"))


### PR DESCRIPTION
This makes the IDE/editor experience *slightly* more tolerable :stuck_out_tongue:

Example: https://gitcdn.link/cdn/mars-research/pal/bd9fe2ed938178efeca215dfe25a0b0dbb03b294/pal/vmcs/vm_exit_controls/index.html