### PR TITLE
rust: Mark all functions as unsafe

### DIFF
--- a/example/rust/intel/src/basic_usage.rs
+++ b/example/rust/intel/src/basic_usage.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn run_example() {
+pub unsafe fn run_example() {
     // PAL lets you interact with instructions and registers using their name
     // as defined by a reference manual. For example, read the
     // IA32_FEATURE_CONTROL MSR, and then print its value:

--- a/example/rust/intel/src/hypercall.rs
+++ b/example/rust/intel/src/hypercall.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn run_example() {
+pub unsafe fn run_example() {
     // Execute the Intel VMCALL instruction with no arguments
     pal::instruction::execute_vmcall();
 

--- a/example/rust/intel/src/main.rs
+++ b/example/rust/intel/src/main.rs
@@ -2,6 +2,8 @@ mod basic_usage;
 mod hypercall;
 
 fn main() {
-    basic_usage::run_example();
-    hypercall::run_example();
+    unsafe {
+        basic_usage::run_example();
+        hypercall::run_example();
+    }
 }

--- a/pal/gadget/rust/function_definition.py
+++ b/pal/gadget/rust/function_definition.py
@@ -52,7 +52,7 @@ def function_definition(decorated):
         /// Short summary of the function.
         ///
         /// And here are the details.
-        pub fn my_function(arg1: u64) -> u64 {
+        pub unsafe fn my_function(arg1: u64) -> u64 {
             contents inside function body
         }
     """
@@ -67,7 +67,7 @@ def function_definition(decorated):
         if properties.pub == True:
             outfile.write("pub ")
 
-        outfile.write("fn ")
+        outfile.write("unsafe fn ")
         outfile.write(str(properties.name))
 
 

--- a/test/rust/intel/src/cpuid.rs
+++ b/test/rust/intel/src/cpuid.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_cpuid_compile()
+pub unsafe fn test_cpuid_compile()
 {
     let leaf = 0x1;
     let subleaf = 0x0;

--- a/test/rust/intel/src/cr3.rs
+++ b/test/rust/intel/src/cr3.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_cr3_compile()
+pub unsafe fn test_cr3_compile()
 {
     // Register accessors
     pal::control_register::cr3::set(0xA55A5AA5);

--- a/test/rust/intel/src/eptp.rs
+++ b/test/rust/intel/src/eptp.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_eptp_compile()
+pub unsafe fn test_eptp_compile()
 {
     // Register accessors
     pal::vmcs::eptp::set(0xA55A5AA5);

--- a/test/rust/intel/src/guest_interrupt_status.rs
+++ b/test/rust/intel/src/guest_interrupt_status.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_guest_interrupt_status_compile()
+pub unsafe fn test_guest_interrupt_status_compile()
 {
     // Register accessors
     pal::vmcs::guest_interrupt_status::set(0xA55A);

--- a/test/rust/intel/src/ia32_feature_control.rs
+++ b/test/rust/intel/src/ia32_feature_control.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_ia32_feature_control_compile()
+pub unsafe fn test_ia32_feature_control_compile()
 {
     // Register accessors
     pal::msr::ia32_feature_control::set(0xA55A5AA5A55A5AA5);

--- a/test/rust/intel/src/leaf_01.rs
+++ b/test/rust/intel/src/leaf_01.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_leaf_01_compile()
+pub unsafe fn test_leaf_01_compile()
 {
     let eax = pal::cpuid::leaf_01_eax::get();
     let _ebx = pal::cpuid::leaf_01_ebx::get();

--- a/test/rust/intel/src/leaf_04.rs
+++ b/test/rust/intel/src/leaf_04.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_leaf_04_compile()
+pub unsafe fn test_leaf_04_compile()
 {
     let eax = pal::cpuid::leaf_04_eax::get_at_index(1);
     let _ebx = pal::cpuid::leaf_04_ebx::get_at_index(1);

--- a/test/rust/intel/src/leaf_0d.rs
+++ b/test/rust/intel/src/leaf_0d.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_leaf_0d_compile()
+pub unsafe fn test_leaf_0d_compile()
 {
     let eax = pal::cpuid::leaf_0d_eax::get_at_index(1);
     let _ebx = pal::cpuid::leaf_0d_ebx::get_at_index(1);

--- a/test/rust/intel/src/main.rs
+++ b/test/rust/intel/src/main.rs
@@ -17,19 +17,20 @@ mod write_cr3;
 mod xcr0;
 
 fn main() {
-
-    cr3::test_cr3_compile();
-    cpuid::test_cpuid_compile();
-    eptp::test_eptp_compile();
-    guest_interrupt_status::test_guest_interrupt_status_compile();
-    ia32_feature_control::test_ia32_feature_control_compile();
-    rdmsr::test_rdmsr_compile();
-    leaf_01::test_leaf_01_compile();
-    leaf_04::test_leaf_04_compile();
-    leaf_0d::test_leaf_0d_compile();
-    read_cr3::test_read_cr3_compile();
-    write_cr3::test_write_cr3_compile();
-    xcr0::test_xcr0_compile();
+    unsafe {
+        cr3::test_cr3_compile();
+        cpuid::test_cpuid_compile();
+        eptp::test_eptp_compile();
+        guest_interrupt_status::test_guest_interrupt_status_compile();
+        ia32_feature_control::test_ia32_feature_control_compile();
+        rdmsr::test_rdmsr_compile();
+        leaf_01::test_leaf_01_compile();
+        leaf_04::test_leaf_04_compile();
+        leaf_0d::test_leaf_0d_compile();
+        read_cr3::test_read_cr3_compile();
+        write_cr3::test_write_cr3_compile();
+        xcr0::test_xcr0_compile();
+    }
 }
 
 #[cfg(not(feature = "std"))]

--- a/test/rust/intel/src/rdmsr.rs
+++ b/test/rust/intel/src/rdmsr.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_rdmsr_compile()
+pub unsafe fn test_rdmsr_compile()
 {
     let address = pal::msr::ia32_feature_control::ADDRESS;
     let value = pal::instruction::execute_rdmsr(address);

--- a/test/rust/intel/src/read_cr3.rs
+++ b/test/rust/intel/src/read_cr3.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_read_cr3_compile()
+pub unsafe fn test_read_cr3_compile()
 {
     let value = pal::instruction::execute_read_cr3();
 

--- a/test/rust/intel/src/write_cr3.rs
+++ b/test/rust/intel/src/write_cr3.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_write_cr3_compile()
+pub unsafe fn test_write_cr3_compile()
 {
     pal::instruction::execute_write_cr3(0xDEADBEEF);
 }

--- a/test/rust/intel/src/xcr0.rs
+++ b/test/rust/intel/src/xcr0.rs
@@ -1,6 +1,6 @@
 use pal;
 
-pub fn test_xcr0_compile()
+pub unsafe fn test_xcr0_compile()
 {
     // Register accessors
     pal::control_register::xcr0::set(0xA55A5AA5);


### PR DESCRIPTION
Consistent with other crates like [x86](https://docs.rs/x86/0.42.1/x86/msr/index.html), low-level register manipulation functions break safety guarantees and should be marked unsafe themselves.