### PR TITLE
Introduce Chipsec-for-ARM capability

### DIFF
--- a/data/armv8a/register/aarch64/sctlr_el1.yml
+++ b/data/armv8a/register/aarch64/sctlr_el1.yml
@@ -333,5 +333,135 @@
 
           - name: 0
             lsb: 45
+            msb: 45
+            reserved0: True
+
+          - name: TWEDEn
+            lsb: 45
+            msb: 45
+
+          - name: 0
+            lsb: 46
+            msb: 49
+            reserved0: True
+
+          - name: TWEDEL
+            lsb: 46
+            msb: 49
+
+          - name: 0
+            lsb: 50
+            msb: 50
+            reserved0: True
+
+          - name: TMT0
+            lsb: 50
+            msb: 50
+
+          - name: 0
+            lsb: 51
+            msb: 51
+            reserved0: True
+
+          - name: TMT
+            lsb: 51
+            msb: 51
+
+          - name: 0
+            lsb: 52
+            msb: 52
+            reserved0: True
+
+          - name: TME0
+            lsb: 52
+            msb: 52
+
+          - name: 0
+            lsb: 53
+            msb: 53
+            reserved0: True
+
+          - name: TME
+            lsb: 53
+            msb: 53
+
+          - name: 0
+            lsb: 54
+            msb: 54
+            reserved0: True
+
+          - name: EnASR
+            lsb: 54
+            msb: 54
+
+          - name: 0
+            lsb: 55
+            msb: 55
+            reserved0: True
+
+          - name: EnAS0
+            lsb: 55
+            msb: 55
+
+          - name: 0
+            lsb: 56
+            msb: 56
+            reserved0: True
+
+          - name: EnALS
+            lsb: 56
+            msb: 56
+
+          - name: 0
+            lsb: 57
+            msb: 57
+            reserved0: True
+
+          - name: EPAN
+            lsb: 57
+            msb: 57
+
+          - name: 0
+            lsb: 58
+            msb: 59
+            reserved0: True
+
+          - name: RES0
+            lsb: 58
+            msb: 59
+
+          - name: 0
+            lsb: 60
+            msb: 60
+            reserved0: True
+
+          - name: EnTP2
+            lsb: 60
+            msb: 60
+
+          - name: 0
+            lsb: 61
+            msb: 61
+            reserved0: True
+
+          - name: NMI
+            lsb: 61
+            msb: 61
+
+          - name: 0
+            lsb: 62
+            msb: 62
+            reserved0: True
+
+          - name: SPINTMASK
+            lsb: 62
+            msb: 62
+
+          - name: 0
+            lsb: 63
             msb: 63
             reserved0: True
+
+          - name: TIDCP
+            lsb: 63
+            msb: 63

--- a/devpal/include/devpal_abi_armv8a_aarch64.h
+++ b/devpal/include/devpal_abi_armv8a_aarch64.h
@@ -18,6 +18,7 @@ typedef UINT64 uint64_t;
 
 // ----------------------------------------------------------------------------
 struct sys_inputs {
+    uint8_t op0;
     uint8_t op1;
     uint8_t crn;
     uint8_t crm;
@@ -30,6 +31,7 @@ struct sys_operands {
 };
 // ----------------------------------------------------------------------------
 struct sysl_inputs {
+    uint8_t op0;
     uint8_t op1;
     uint8_t crn;
     uint8_t crm;

--- a/devpal/include/devpal_abi_armv8a_aarch64.h
+++ b/devpal/include/devpal_abi_armv8a_aarch64.h
@@ -16,6 +16,7 @@ typedef UINT64 uint64_t;
 #define DEVPAL_EXECUTE_SYS 0xFD000000
 #define DEVPAL_EXECUTE_SYSL 0xFD000001
 #define DEVPAL_EXECUTE_SMC 0xFD000002
+#define DEVPAL_EXECUTE_HVC 0xFD000003
 
 // ----------------------------------------------------------------------------
 struct sys_inputs {
@@ -66,9 +67,6 @@ struct smc_inputs
     uint64_t X12;
     uint64_t X13;
     uint64_t X14;
-    uint64_t X15;
-    uint64_t X16;
-    uint64_t X17;
 };
 
 struct smc_outputs
@@ -88,14 +86,56 @@ struct smc_outputs
     uint64_t X12;
     uint64_t X13;
     uint64_t X14;
-    uint64_t X15;
-    uint64_t X16;
-    uint64_t X17;
 };
 
 struct smc_operands
 {
     struct smc_inputs in;
     struct smc_outputs out;
+};
+
+// ----------------------------------------------------------------------------
+struct hvc_inputs
+{
+    uint64_t W0;
+    uint64_t X1;
+    uint64_t X2;
+    uint64_t X3;
+    uint64_t X4;
+    uint64_t X5;
+    uint64_t X6;
+    uint64_t X7;
+    uint64_t X8;
+    uint64_t X9;
+    uint64_t X10;
+    uint64_t X11;
+    uint64_t X12;
+    uint64_t X13;
+    uint64_t X14;
+};
+
+struct hvc_outputs
+{
+    uint64_t X0;
+    uint64_t X1;
+    uint64_t X2;
+    uint64_t X3;
+    uint64_t X4;
+    uint64_t X5;
+    uint64_t X6;
+    uint64_t X7;
+    uint64_t X8;
+    uint64_t X9;
+    uint64_t X10;
+    uint64_t X11;
+    uint64_t X12;
+    uint64_t X13;
+    uint64_t X14;
+};
+
+struct hvc_operands
+{
+    struct hvc_inputs in;
+    struct hvc_outputs out;
 };
 #endif

--- a/devpal/include/devpal_abi_armv8a_aarch64.h
+++ b/devpal/include/devpal_abi_armv8a_aarch64.h
@@ -15,6 +15,7 @@ typedef UINT64 uint64_t;
 
 #define DEVPAL_EXECUTE_SYS 0xFD000000
 #define DEVPAL_EXECUTE_SYSL 0xFD000001
+#define DEVPAL_EXECUTE_SMC 0xFD000002
 
 // ----------------------------------------------------------------------------
 struct sys_inputs {
@@ -47,4 +48,54 @@ struct sysl_operands {
     struct sysl_outputs out;
 };
 
+// ----------------------------------------------------------------------------
+struct smc_inputs
+{
+    uint64_t W0;
+    uint64_t X1;
+    uint64_t X2;
+    uint64_t X3;
+    uint64_t X4;
+    uint64_t X5;
+    uint64_t X6;
+    uint64_t X7;
+    uint64_t X8;
+    uint64_t X9;
+    uint64_t X10;
+    uint64_t X11;
+    uint64_t X12;
+    uint64_t X13;
+    uint64_t X14;
+    uint64_t X15;
+    uint64_t X16;
+    uint64_t X17;
+};
+
+struct smc_outputs
+{
+    uint64_t X0;
+    uint64_t X1;
+    uint64_t X2;
+    uint64_t X3;
+    uint64_t X4;
+    uint64_t X5;
+    uint64_t X6;
+    uint64_t X7;
+    uint64_t X8;
+    uint64_t X9;
+    uint64_t X10;
+    uint64_t X11;
+    uint64_t X12;
+    uint64_t X13;
+    uint64_t X14;
+    uint64_t X15;
+    uint64_t X16;
+    uint64_t X17;
+};
+
+struct smc_operands
+{
+    struct smc_inputs in;
+    struct smc_outputs out;
+};
 #endif

--- a/devpal/linux/CMakeLists.txt
+++ b/devpal/linux/CMakeLists.txt
@@ -50,6 +50,7 @@ if(PAL_ARMV8A_AARCH64_LINUX_IOCTL)
         armv8a/aarch64/sys.c
         armv8a/aarch64/sysl.c
         armv8a/aarch64/smc.c
+        armv8a/aarch64/hvc.c
     )
 endif()
 

--- a/devpal/linux/CMakeLists.txt
+++ b/devpal/linux/CMakeLists.txt
@@ -49,6 +49,7 @@ if(PAL_ARMV8A_AARCH64_LINUX_IOCTL)
         armv8a/aarch64/ioctl.c
         armv8a/aarch64/sys.c
         armv8a/aarch64/sysl.c
+        armv8a/aarch64/smc.c
     )
 endif()
 

--- a/devpal/linux/CMakeLists.txt
+++ b/devpal/linux/CMakeLists.txt
@@ -69,6 +69,7 @@ set(EXTRA_CFLAGS_LIST
     "-D__kernel__"
     "-I${PAL_SOURCE_ROOT_DIR}/devpal/include"
     "-I${PAL_SOURCE_ROOT_DIR}/libpal/intel_64bit_systemv_gnuinline/include"
+    "-I${PAL_SOURCE_ROOT_DIR}/libpal/armv8a_aarch64_aapcs64_gnuinline/include"
 )
 string(REPLACE ";" " " EXTRA_CFLAGS "${EXTRA_CFLAGS_LIST}")
 

--- a/devpal/linux/armv8a/aarch64/hvc.c
+++ b/devpal/linux/armv8a/aarch64/hvc.c
@@ -1,0 +1,37 @@
+#include <linux/uaccess.h>
+#include "devpal_abi_armv8a_aarch64.h"
+#include <linux/printk.h>
+#include "pal/aarch64/hvc_inline.h"
+
+long handle_devpal_ioctl_hvc(struct hvc_operands * user_ops)
+{
+
+    struct hvc_operands kern_ops = {0};
+    struct hvc_operands output = {0};
+
+    if (copy_from_user(&kern_ops, user_ops, sizeof(struct hvc_operands)))
+        return -1;
+
+    output = pal_execute_hvc_inline(&kern_ops);
+
+    kern_ops.out.X0 = output.out.X0;
+    kern_ops.out.X1 = output.out.X1;
+    kern_ops.out.X2 = output.out.X2;
+    kern_ops.out.X3 = output.out.X3;
+    kern_ops.out.X4 = output.out.X4;
+    kern_ops.out.X5 = output.out.X5;
+    kern_ops.out.X6 = output.out.X6;
+    kern_ops.out.X7 = output.out.X7;
+    kern_ops.out.X8 = output.out.X8;
+    kern_ops.out.X9 = output.out.X9;
+    kern_ops.out.X10 = output.out.X10;
+    kern_ops.out.X11 = output.out.X11;
+    kern_ops.out.X12 = output.out.X12;
+    kern_ops.out.X13 = output.out.X13;
+    kern_ops.out.X14 = output.out.X14;
+
+    if (copy_to_user(user_ops, &kern_ops, sizeof(struct hvc_operands)))
+        return -1;
+
+    return 0;
+}

--- a/devpal/linux/armv8a/aarch64/ioctl.c
+++ b/devpal/linux/armv8a/aarch64/ioctl.c
@@ -11,6 +11,7 @@
 long handle_devpal_ioctl_sys(struct sys_operands * user_ops);
 long handle_devpal_ioctl_sysl(struct sysl_operands * user_ops);
 long handle_devpal_ioctl_smc(struct smc_operands *user_ops);
+long handle_devpal_ioctl_hvc(struct hvc_operands *user_ops);
 
 long handle_devpal_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
@@ -24,6 +25,9 @@ long handle_devpal_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
         case DEVPAL_EXECUTE_SMC:
             return handle_devpal_ioctl_smc((struct smc_operands *)arg);
+
+        case DEVPAL_EXECUTE_HVC:
+            return handle_devpal_ioctl_hvc((struct hvc_operands *)arg);
 
         default:
             return -EINVAL;

--- a/devpal/linux/armv8a/aarch64/ioctl.c
+++ b/devpal/linux/armv8a/aarch64/ioctl.c
@@ -10,12 +10,21 @@
 
 long handle_devpal_ioctl_sys(struct sys_operands * user_ops);
 long handle_devpal_ioctl_sysl(struct sysl_operands * user_ops);
-long handle_devpal_ioctl_smc(struct smc_operands *user_ops);
-long handle_devpal_ioctl_hvc(struct hvc_operands *user_ops);
+long handle_devpal_ioctl_smc(struct smc_operands * user_ops);
+long handle_devpal_ioctl_hvc(struct hvc_operands * user_ops);
+long handle_devpal_ioctl_read_mem8(struct read_mem8_operands *user_ops);
+long handle_devpal_ioctl_read_mem16(struct read_mem16_operands *user_ops);
+long handle_devpal_ioctl_read_mem32(struct read_mem32_operands *user_ops);
+long handle_devpal_ioctl_read_mem64(struct read_mem64_operands *user_ops);
+long handle_devpal_ioctl_write_mem8(struct write_mem8_operands *user_ops);
+long handle_devpal_ioctl_write_mem16(struct write_mem16_operands *user_ops);
+long handle_devpal_ioctl_write_mem32(struct write_mem32_operands *user_ops);
+long handle_devpal_ioctl_write_mem64(struct write_mem64_operands *user_ops);
 
 long handle_devpal_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
     printk("[devpal] ioctl: %u\n", cmd);
+
     switch (cmd) {
         case DEVPAL_EXECUTE_SYS:
             return handle_devpal_ioctl_sys((struct sys_operands *)arg);
@@ -28,6 +37,30 @@ long handle_devpal_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
         case DEVPAL_EXECUTE_HVC:
             return handle_devpal_ioctl_hvc((struct hvc_operands *)arg);
+
+        case DEVPAL_EXECUTE_READ_MEM8:
+            return handle_devpal_ioctl_read_mem8((struct read_mem8_operands *)arg);
+
+        case DEVPAL_EXECUTE_READ_MEM16:
+            return handle_devpal_ioctl_read_mem16((struct read_mem16_operands *)arg);
+
+        case DEVPAL_EXECUTE_READ_MEM32:
+            return handle_devpal_ioctl_read_mem32((struct read_mem32_operands *)arg);
+
+        case DEVPAL_EXECUTE_READ_MEM64:
+            return handle_devpal_ioctl_read_mem64((struct read_mem64_operands *)arg);
+
+        case DEVPAL_EXECUTE_WRITE_MEM8:
+            return handle_devpal_ioctl_write_mem8((struct write_mem8_operands *)arg);
+
+        case DEVPAL_EXECUTE_WRITE_MEM16:
+            return handle_devpal_ioctl_write_mem16((struct write_mem16_operands *)arg);
+
+        case DEVPAL_EXECUTE_WRITE_MEM32:
+            return handle_devpal_ioctl_write_mem32((struct write_mem32_operands *)arg);
+
+        case DEVPAL_EXECUTE_WRITE_MEM64:
+            return handle_devpal_ioctl_write_mem64((struct write_mem64_operands *)arg);
 
         default:
             return -EINVAL;

--- a/devpal/linux/armv8a/aarch64/ioctl.c
+++ b/devpal/linux/armv8a/aarch64/ioctl.c
@@ -10,6 +10,7 @@
 
 long handle_devpal_ioctl_sys(struct sys_operands * user_ops);
 long handle_devpal_ioctl_sysl(struct sysl_operands * user_ops);
+long handle_devpal_ioctl_smc(struct smc_operands *user_ops);
 
 long handle_devpal_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
@@ -20,6 +21,9 @@ long handle_devpal_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
         case DEVPAL_EXECUTE_SYSL:
             return handle_devpal_ioctl_sysl((struct sysl_operands *)arg);
+
+        case DEVPAL_EXECUTE_SMC:
+            return handle_devpal_ioctl_smc((struct smc_operands *)arg);
 
         default:
             return -EINVAL;

--- a/devpal/linux/armv8a/aarch64/smc.c
+++ b/devpal/linux/armv8a/aarch64/smc.c
@@ -1,0 +1,40 @@
+#include <linux/uaccess.h>
+#include "devpal_abi_armv8a_aarch64.h"
+#include <linux/printk.h>
+#include "pal/aarch64/smc_inline.h"
+
+long handle_devpal_ioctl_smc(struct smc_operands * user_ops)
+{
+
+    struct smc_operands kern_ops = {0};
+    struct smc_operands output = {0};
+
+    if (copy_from_user(&kern_ops, user_ops, sizeof(struct smc_operands)))
+        return -1;
+
+    output = pal_execute_smc_inline(&kern_ops);
+
+    kern_ops.out.X0 = output.out.X0;
+    kern_ops.out.X1 = output.out.X1;
+    kern_ops.out.X2 = output.out.X2;
+    kern_ops.out.X3 = output.out.X3;
+    kern_ops.out.X4 = output.out.X4;
+    kern_ops.out.X5 = output.out.X5;
+    kern_ops.out.X6 = output.out.X6;
+    kern_ops.out.X7 = output.out.X7;
+    kern_ops.out.X8 = output.out.X8;
+    kern_ops.out.X9 = output.out.X9;
+    kern_ops.out.X10 = output.out.X10;
+    kern_ops.out.X11 = output.out.X11;
+    kern_ops.out.X12 = output.out.X12;
+    kern_ops.out.X13 = output.out.X13;
+    kern_ops.out.X14 = output.out.X14;
+    kern_ops.out.X15 = output.out.X15;
+    kern_ops.out.X16 = output.out.X16;
+    kern_ops.out.X17 = output.out.X17;
+
+    if (copy_to_user(user_ops, &kern_ops, sizeof(struct smc_operands)))
+        return -1;
+
+    return 0;
+}

--- a/devpal/linux/armv8a/aarch64/smc.c
+++ b/devpal/linux/armv8a/aarch64/smc.c
@@ -29,9 +29,6 @@ long handle_devpal_ioctl_smc(struct smc_operands * user_ops)
     kern_ops.out.X12 = output.out.X12;
     kern_ops.out.X13 = output.out.X13;
     kern_ops.out.X14 = output.out.X14;
-    kern_ops.out.X15 = output.out.X15;
-    kern_ops.out.X16 = output.out.X16;
-    kern_ops.out.X17 = output.out.X17;
 
     if (copy_to_user(user_ops, &kern_ops, sizeof(struct smc_operands)))
         return -1;

--- a/devpal/linux/armv8a/aarch64/sys.c
+++ b/devpal/linux/armv8a/aarch64/sys.c
@@ -19,10 +19,13 @@ long handle_devpal_ioctl_sys(struct sys_operands * user_ops)
     op2 = kern_ops.in.op2;
     value = kern_ops.in.value;
 
-    // TODO: Implement Me!
-    //  - take the fields that make up the encoding for the A64 SYS instruction
-    //  - calculate the instruction encoding
-    //  - map the encoding to a function implemented within the driver
+    printk("Here: val= %llx", value);
+
+    // inline assembly for msr
+    __asm__ volatile("msr s3_0_c1_c0_0 , %0"
+                     :
+                     : "r"(value));
+
 
     return 0;
 }

--- a/devpal/linux/armv8a/aarch64/sys.c
+++ b/devpal/linux/armv8a/aarch64/sys.c
@@ -1,30 +1,1640 @@
 #include <linux/uaccess.h>
 #include "devpal_abi_armv8a_aarch64.h"
+#include "pal/aarch64/sys_inline.h"
 
 long handle_devpal_ioctl_sys(struct sys_operands * user_ops)
 {
+    uint8_t op0 = 0;
     uint8_t op1 = 0;
     uint8_t crn = 0;
     uint8_t crm = 0;
     uint8_t op2 = 0;
     uint64_t value = 0;
+    uint32_t switch_vector = 0;
     struct sys_operands kern_ops = {0};
 
     if (copy_from_user(&kern_ops, user_ops, sizeof(struct sys_operands)))
         return -1;
 
+    op0 = kern_ops.in.op0;
     op1 = kern_ops.in.op1;
     crn = kern_ops.in.crn;
     crm = kern_ops.in.crm;
     op2 = kern_ops.in.op2;
     value = kern_ops.in.value;
 
-    printk("Here: val= %llx", value);
+    // The switch vector the sys/sysl instruction encodin, the last 5 bits are not used for our purposes
+    switch_vector |= (op0 & 0x3) << 19;
+    switch_vector |= (op1 & 0x7) << 16;
+    switch_vector |= (crn & 0xF) << 12;
+    switch_vector |= (crm & 0xF) << 8;
+    switch_vector |= (op2 & 0x7) << 5;
 
-    // inline assembly for msr
-    __asm__ volatile("msr s3_0_c1_c0_0 , %0"
-                     :
-                     : "r"(value));
+    //printk("Vector: val= %x", switch_vector);
+
+    switch (switch_vector)
+    {
+    case 0x181020:
+        pal_set_actlr_el1_inline(value);
+        break;
+    case 0x1c1020:
+        pal_set_actlr_el2_inline(value);
+        break;
+    case 0x1e1020:
+        pal_set_actlr_el3_inline(value);
+        break;
+    case 0x185100:
+        pal_set_afsr0_el1_inline(value);
+        break;
+    case 0x1c5100:
+        pal_set_afsr0_el2_inline(value);
+        break;
+    case 0x1e5100:
+        pal_set_afsr0_el3_inline(value);
+        break;
+    case 0x185120:
+        pal_set_afsr1_el1_inline(value);
+        break;
+    case 0x1c5120:
+        pal_set_afsr1_el2_inline(value);
+        break;
+    case 0x1e5120:
+        pal_set_afsr1_el3_inline(value);
+        break;
+    case 0x1900e0:
+        pal_set_aidr_el1_inline(value);
+        break;
+    case 0x18a300:
+        pal_set_amair_el1_inline(value);
+        break;
+    case 0x1ca300:
+        pal_set_amair_el2_inline(value);
+        break;
+    case 0x1ea300:
+        pal_set_amair_el3_inline(value);
+        break;
+    case 0x1bd220:
+        pal_set_amcfgr_el0_inline(value);
+        break;
+    case 0x1bd240:
+        pal_set_amcgcr_el0_inline(value);
+        break;
+    case 0x1bd280:
+        pal_set_amcntenclr0_el0_inline(value);
+        break;
+    case 0x1bd300:
+        pal_set_amcntenclr1_el0_inline(value);
+        break;
+    case 0x1bd2a0:
+        pal_set_amcntenset0_el0_inline(value);
+        break;
+    case 0x1bd320:
+        pal_set_amcntenset1_el0_inline(value);
+        break;
+    case 0x1bd200:
+        pal_set_amcr_el0_inline(value);
+        break;
+    case 0x1bd400:
+        pal_set_amevcntr00_el0_inline(value);
+        break;
+    case 0x1bd540:
+        pal_set_amevcntr010_el0_inline(value);
+        break;
+    case 0x1bd560:
+        pal_set_amevcntr011_el0_inline(value);
+        break;
+    case 0x1bd580:
+        pal_set_amevcntr012_el0_inline(value);
+        break;
+    case 0x1bd5a0:
+        pal_set_amevcntr013_el0_inline(value);
+        break;
+    case 0x1bd5c0:
+        pal_set_amevcntr014_el0_inline(value);
+        break;
+    case 0x1bd5e0:
+        pal_set_amevcntr015_el0_inline(value);
+        break;
+    case 0x1bd420:
+        pal_set_amevcntr01_el0_inline(value);
+        break;
+    case 0x1bd440:
+        pal_set_amevcntr02_el0_inline(value);
+        break;
+    case 0x1bd460:
+        pal_set_amevcntr03_el0_inline(value);
+        break;
+    case 0x1bd480:
+        pal_set_amevcntr04_el0_inline(value);
+        break;
+    case 0x1bd4a0:
+        pal_set_amevcntr05_el0_inline(value);
+        break;
+    case 0x1bd4c0:
+        pal_set_amevcntr06_el0_inline(value);
+        break;
+    case 0x1bd4e0:
+        pal_set_amevcntr07_el0_inline(value);
+        break;
+    case 0x1bd500:
+        pal_set_amevcntr08_el0_inline(value);
+        break;
+    case 0x1bd520:
+        pal_set_amevcntr09_el0_inline(value);
+        break;
+    case 0x1bdc00:
+        pal_set_amevcntr10_el0_inline(value);
+        break;
+    case 0x1bdd40:
+        pal_set_amevcntr110_el0_inline(value);
+        break;
+    case 0x1bdd60:
+        pal_set_amevcntr111_el0_inline(value);
+        break;
+    case 0x1bdd80:
+        pal_set_amevcntr112_el0_inline(value);
+        break;
+    case 0x1bdda0:
+        pal_set_amevcntr113_el0_inline(value);
+        break;
+    case 0x1bddc0:
+        pal_set_amevcntr114_el0_inline(value);
+        break;
+    case 0x1bdde0:
+        pal_set_amevcntr115_el0_inline(value);
+        break;
+    case 0x1bdc20:
+        pal_set_amevcntr11_el0_inline(value);
+        break;
+    case 0x1bdc40:
+        pal_set_amevcntr12_el0_inline(value);
+        break;
+    case 0x1bdc60:
+        pal_set_amevcntr13_el0_inline(value);
+        break;
+    case 0x1bdc80:
+        pal_set_amevcntr14_el0_inline(value);
+        break;
+    case 0x1bdca0:
+        pal_set_amevcntr15_el0_inline(value);
+        break;
+    case 0x1bdcc0:
+        pal_set_amevcntr16_el0_inline(value);
+        break;
+    case 0x1bdce0:
+        pal_set_amevcntr17_el0_inline(value);
+        break;
+    case 0x1bdd00:
+        pal_set_amevcntr18_el0_inline(value);
+        break;
+    case 0x1bdd20:
+        pal_set_amevcntr19_el0_inline(value);
+        break;
+    case 0x1bd600:
+        pal_set_amevtyper00_el0_inline(value);
+        break;
+    case 0x1bd740:
+        pal_set_amevtyper010_el0_inline(value);
+        break;
+    case 0x1bd760:
+        pal_set_amevtyper011_el0_inline(value);
+        break;
+    case 0x1bd780:
+        pal_set_amevtyper012_el0_inline(value);
+        break;
+    case 0x1bd7a0:
+        pal_set_amevtyper013_el0_inline(value);
+        break;
+    case 0x1bd7c0:
+        pal_set_amevtyper014_el0_inline(value);
+        break;
+    case 0x1bd7e0:
+        pal_set_amevtyper015_el0_inline(value);
+        break;
+    case 0x1bd620:
+        pal_set_amevtyper01_el0_inline(value);
+        break;
+    case 0x1bd640:
+        pal_set_amevtyper02_el0_inline(value);
+        break;
+    case 0x1bd660:
+        pal_set_amevtyper03_el0_inline(value);
+        break;
+    case 0x1bd680:
+        pal_set_amevtyper04_el0_inline(value);
+        break;
+    case 0x1bd6a0:
+        pal_set_amevtyper05_el0_inline(value);
+        break;
+    case 0x1bd6c0:
+        pal_set_amevtyper06_el0_inline(value);
+        break;
+    case 0x1bd6e0:
+        pal_set_amevtyper07_el0_inline(value);
+        break;
+    case 0x1bd700:
+        pal_set_amevtyper08_el0_inline(value);
+        break;
+    case 0x1bd720:
+        pal_set_amevtyper09_el0_inline(value);
+        break;
+    case 0x1bde00:
+        pal_set_amevtyper10_el0_inline(value);
+        break;
+    case 0x1bdf40:
+        pal_set_amevtyper110_el0_inline(value);
+        break;
+    case 0x1bdf60:
+        pal_set_amevtyper111_el0_inline(value);
+        break;
+    case 0x1bdf80:
+        pal_set_amevtyper112_el0_inline(value);
+        break;
+    case 0x1bdfa0:
+        pal_set_amevtyper113_el0_inline(value);
+        break;
+    case 0x1bdfc0:
+        pal_set_amevtyper114_el0_inline(value);
+        break;
+    case 0x1bdfe0:
+        pal_set_amevtyper115_el0_inline(value);
+        break;
+    case 0x1bde20:
+        pal_set_amevtyper11_el0_inline(value);
+        break;
+    case 0x1bde40:
+        pal_set_amevtyper12_el0_inline(value);
+        break;
+    case 0x1bde60:
+        pal_set_amevtyper13_el0_inline(value);
+        break;
+    case 0x1bde80:
+        pal_set_amevtyper14_el0_inline(value);
+        break;
+    case 0x1bdea0:
+        pal_set_amevtyper15_el0_inline(value);
+        break;
+    case 0x1bdec0:
+        pal_set_amevtyper16_el0_inline(value);
+        break;
+    case 0x1bdee0:
+        pal_set_amevtyper17_el0_inline(value);
+        break;
+    case 0x1bdf00:
+        pal_set_amevtyper18_el0_inline(value);
+        break;
+    case 0x1bdf20:
+        pal_set_amevtyper19_el0_inline(value);
+        break;
+    case 0x1bd260:
+        pal_set_amuserenr_el0_inline(value);
+        break;
+    case 0x182220:
+        pal_set_apdakeyhi_el1_inline(value);
+        break;
+    case 0x182200:
+        pal_set_apdakeylo_el1_inline(value);
+        break;
+    case 0x182260:
+        pal_set_apdbkeyhi_el1_inline(value);
+        break;
+    case 0x182240:
+        pal_set_apdbkeylo_el1_inline(value);
+        break;
+    case 0x182320:
+        pal_set_apgakeyhi_el1_inline(value);
+        break;
+    case 0x182300:
+        pal_set_apgakeylo_el1_inline(value);
+        break;
+    case 0x182120:
+        pal_set_apiakeyhi_el1_inline(value);
+        break;
+    case 0x182100:
+        pal_set_apiakeylo_el1_inline(value);
+        break;
+    case 0x182160:
+        pal_set_apibkeyhi_el1_inline(value);
+        break;
+    case 0x182140:
+        pal_set_apibkeylo_el1_inline(value);
+        break;
+    case 0x190040:
+        pal_set_ccsidr2_el1_inline(value);
+        break;
+    case 0x190000:
+        pal_set_ccsidr_el1_inline(value);
+        break;
+    case 0x190020:
+        pal_set_clidr_el1_inline(value);
+        break;
+    case 0x1be000:
+        pal_set_cntfrq_el0_inline(value);
+        break;
+    case 0x1ce100:
+        pal_set_cnthctl_el2_inline(value);
+        break;
+    case 0x1ce220:
+        pal_set_cnthp_ctl_el2_inline(value);
+        break;
+    case 0x1ce240:
+        pal_set_cnthp_cval_el2_inline(value);
+        break;
+    case 0x1ce200:
+        pal_set_cnthp_tval_el2_inline(value);
+        break;
+    case 0x1ce520:
+        pal_set_cnthps_ctl_el2_inline(value);
+        break;
+    case 0x1ce540:
+        pal_set_cnthps_cval_el2_inline(value);
+        break;
+    case 0x1ce500:
+        pal_set_cnthps_tval_el2_inline(value);
+        break;
+    case 0x1ce320:
+        pal_set_cnthv_ctl_el2_inline(value);
+        break;
+    case 0x1ce340:
+        pal_set_cnthv_cval_el2_inline(value);
+        break;
+    case 0x1ce300:
+        pal_set_cnthv_tval_el2_inline(value);
+        break;
+    case 0x1ce420:
+        pal_set_cnthvs_ctl_el2_inline(value);
+        break;
+    case 0x1ce440:
+        pal_set_cnthvs_cval_el2_inline(value);
+        break;
+    case 0x1ce400:
+        pal_set_cnthvs_tval_el2_inline(value);
+        break;
+    case 0x18e100:
+        pal_set_cntkctl_el1_inline(value);
+        break;
+    case 0x1be220:
+        pal_set_cntp_ctl_el0_inline(value);
+        break;
+    case 0x1be240:
+        pal_set_cntp_cval_el0_inline(value);
+        break;
+    case 0x1be200:
+        pal_set_cntp_tval_el0_inline(value);
+        break;
+    case 0x1be020:
+        pal_set_cntpct_el0_inline(value);
+        break;
+    case 0x1fe220:
+        pal_set_cntps_ctl_el1_inline(value);
+        break;
+    case 0x1fe240:
+        pal_set_cntps_cval_el1_inline(value);
+        break;
+    case 0x1fe200:
+        pal_set_cntps_tval_el1_inline(value);
+        break;
+    case 0x1be320:
+        pal_set_cntv_ctl_el0_inline(value);
+        break;
+    case 0x1be340:
+        pal_set_cntv_cval_el0_inline(value);
+        break;
+    case 0x1be300:
+        pal_set_cntv_tval_el0_inline(value);
+        break;
+    case 0x1be040:
+        pal_set_cntvct_el0_inline(value);
+        break;
+    case 0x1ce060:
+        pal_set_cntvoff_el2_inline(value);
+        break;
+    case 0x18d020:
+        pal_set_contextidr_el1_inline(value);
+        break;
+    case 0x1cd020:
+        pal_set_contextidr_el2_inline(value);
+        break;
+    case 0x181040:
+        pal_set_cpacr_el1_inline(value);
+        break;
+    case 0x1c1140:
+        pal_set_cptr_el2_inline(value);
+        break;
+    case 0x1e1140:
+        pal_set_cptr_el3_inline(value);
+        break;
+    case 0x1a0000:
+        pal_set_csselr_el1_inline(value);
+        break;
+    case 0x1b0020:
+        pal_set_ctr_el0_inline(value);
+        break;
+    case 0x184240:
+        pal_set_currentel_inline(value);
+        break;
+    case 0x1c3000:
+        pal_set_dacr32_el2_inline(value);
+        break;
+    case 0x1b4220:
+        pal_set_daif_inline(value);
+        break;
+    case 0x107ec0:
+        pal_set_dbgauthstatus_el1_inline(value);
+        break;
+    case 0x1000a0:
+        pal_set_dbgbcr0_el1_inline(value);
+        break;
+    case 0x100aa0:
+        pal_set_dbgbcr10_el1_inline(value);
+        break;
+    case 0x100ba0:
+        pal_set_dbgbcr11_el1_inline(value);
+        break;
+    case 0x100ca0:
+        pal_set_dbgbcr12_el1_inline(value);
+        break;
+    case 0x100da0:
+        pal_set_dbgbcr13_el1_inline(value);
+        break;
+    case 0x100ea0:
+        pal_set_dbgbcr14_el1_inline(value);
+        break;
+    case 0x100fa0:
+        pal_set_dbgbcr15_el1_inline(value);
+        break;
+    case 0x1001a0:
+        pal_set_dbgbcr1_el1_inline(value);
+        break;
+    case 0x1002a0:
+        pal_set_dbgbcr2_el1_inline(value);
+        break;
+    case 0x1003a0:
+        pal_set_dbgbcr3_el1_inline(value);
+        break;
+    case 0x1004a0:
+        pal_set_dbgbcr4_el1_inline(value);
+        break;
+    case 0x1005a0:
+        pal_set_dbgbcr5_el1_inline(value);
+        break;
+    case 0x1006a0:
+        pal_set_dbgbcr6_el1_inline(value);
+        break;
+    case 0x1007a0:
+        pal_set_dbgbcr7_el1_inline(value);
+        break;
+    case 0x1008a0:
+        pal_set_dbgbcr8_el1_inline(value);
+        break;
+    case 0x1009a0:
+        pal_set_dbgbcr9_el1_inline(value);
+        break;
+    case 0x100080:
+        pal_set_dbgbvr0_el1_inline(value);
+        break;
+    case 0x100a80:
+        pal_set_dbgbvr10_el1_inline(value);
+        break;
+    case 0x100b80:
+        pal_set_dbgbvr11_el1_inline(value);
+        break;
+    case 0x100c80:
+        pal_set_dbgbvr12_el1_inline(value);
+        break;
+    case 0x100d80:
+        pal_set_dbgbvr13_el1_inline(value);
+        break;
+    case 0x100e80:
+        pal_set_dbgbvr14_el1_inline(value);
+        break;
+    case 0x100f80:
+        pal_set_dbgbvr15_el1_inline(value);
+        break;
+    case 0x100180:
+        pal_set_dbgbvr1_el1_inline(value);
+        break;
+    case 0x100280:
+        pal_set_dbgbvr2_el1_inline(value);
+        break;
+    case 0x100380:
+        pal_set_dbgbvr3_el1_inline(value);
+        break;
+    case 0x100480:
+        pal_set_dbgbvr4_el1_inline(value);
+        break;
+    case 0x100580:
+        pal_set_dbgbvr5_el1_inline(value);
+        break;
+    case 0x100680:
+        pal_set_dbgbvr6_el1_inline(value);
+        break;
+    case 0x100780:
+        pal_set_dbgbvr7_el1_inline(value);
+        break;
+    case 0x100880:
+        pal_set_dbgbvr8_el1_inline(value);
+        break;
+    case 0x100980:
+        pal_set_dbgbvr9_el1_inline(value);
+        break;
+    case 0x1079c0:
+        pal_set_dbgclaimclr_el1_inline(value);
+        break;
+    case 0x1078c0:
+        pal_set_dbgclaimset_el1_inline(value);
+        break;
+    case 0x130400:
+        pal_set_dbgdtr_el0_inline(value);
+        break;
+    case 0x130500:
+        pal_set_dbgdtrrx_el0_inline(value);
+        break;
+    case 0x101480:
+        pal_set_dbgprcr_el1_inline(value);
+        break;
+    case 0x140700:
+        pal_set_dbgvcr32_el2_inline(value);
+        break;
+    case 0x1000e0:
+        pal_set_dbgwcr0_el1_inline(value);
+        break;
+    case 0x100ae0:
+        pal_set_dbgwcr10_el1_inline(value);
+        break;
+    case 0x100be0:
+        pal_set_dbgwcr11_el1_inline(value);
+        break;
+    case 0x100ce0:
+        pal_set_dbgwcr12_el1_inline(value);
+        break;
+    case 0x100de0:
+        pal_set_dbgwcr13_el1_inline(value);
+        break;
+    case 0x100ee0:
+        pal_set_dbgwcr14_el1_inline(value);
+        break;
+    case 0x100fe0:
+        pal_set_dbgwcr15_el1_inline(value);
+        break;
+    case 0x1001e0:
+        pal_set_dbgwcr1_el1_inline(value);
+        break;
+    case 0x1002e0:
+        pal_set_dbgwcr2_el1_inline(value);
+        break;
+    case 0x1003e0:
+        pal_set_dbgwcr3_el1_inline(value);
+        break;
+    case 0x1004e0:
+        pal_set_dbgwcr4_el1_inline(value);
+        break;
+    case 0x1005e0:
+        pal_set_dbgwcr5_el1_inline(value);
+        break;
+    case 0x1006e0:
+        pal_set_dbgwcr6_el1_inline(value);
+        break;
+    case 0x1007e0:
+        pal_set_dbgwcr7_el1_inline(value);
+        break;
+    case 0x1008e0:
+        pal_set_dbgwcr8_el1_inline(value);
+        break;
+    case 0x1009e0:
+        pal_set_dbgwcr9_el1_inline(value);
+        break;
+    case 0x1000c0:
+        pal_set_dbgwvr0_el1_inline(value);
+        break;
+    case 0x100ac0:
+        pal_set_dbgwvr10_el1_inline(value);
+        break;
+    case 0x100bc0:
+        pal_set_dbgwvr11_el1_inline(value);
+        break;
+    case 0x100cc0:
+        pal_set_dbgwvr12_el1_inline(value);
+        break;
+    case 0x100dc0:
+        pal_set_dbgwvr13_el1_inline(value);
+        break;
+    case 0x100ec0:
+        pal_set_dbgwvr14_el1_inline(value);
+        break;
+    case 0x100fc0:
+        pal_set_dbgwvr15_el1_inline(value);
+        break;
+    case 0x1001c0:
+        pal_set_dbgwvr1_el1_inline(value);
+        break;
+    case 0x1002c0:
+        pal_set_dbgwvr2_el1_inline(value);
+        break;
+    case 0x1003c0:
+        pal_set_dbgwvr3_el1_inline(value);
+        break;
+    case 0x1004c0:
+        pal_set_dbgwvr4_el1_inline(value);
+        break;
+    case 0x1005c0:
+        pal_set_dbgwvr5_el1_inline(value);
+        break;
+    case 0x1006c0:
+        pal_set_dbgwvr6_el1_inline(value);
+        break;
+    case 0x1007c0:
+        pal_set_dbgwvr7_el1_inline(value);
+        break;
+    case 0x1008c0:
+        pal_set_dbgwvr8_el1_inline(value);
+        break;
+    case 0x1009c0:
+        pal_set_dbgwvr9_el1_inline(value);
+        break;
+    case 0x1b00e0:
+        pal_set_dczid_el0_inline(value);
+        break;
+    case 0x18c120:
+        pal_set_disr_el1_inline(value);
+        break;
+    case 0x1b42a0:
+        pal_set_dit_inline(value);
+        break;
+    case 0x1b4520:
+        pal_set_dlr_el0_inline(value);
+        break;
+    case 0x1b4500:
+        pal_set_dspsr_el0_inline(value);
+        break;
+    case 0x184020:
+        pal_set_elr_el1_inline(value);
+        break;
+    case 0x1c4020:
+        pal_set_elr_el2_inline(value);
+        break;
+    case 0x1e4020:
+        pal_set_elr_el3_inline(value);
+        break;
+    case 0x185300:
+        pal_set_erridr_el1_inline(value);
+        break;
+    case 0x185320:
+        pal_set_errselr_el1_inline(value);
+        break;
+    case 0x185460:
+        pal_set_erxaddr_el1_inline(value);
+        break;
+    case 0x185420:
+        pal_set_erxctlr_el1_inline(value);
+        break;
+    case 0x185400:
+        pal_set_erxfr_el1_inline(value);
+        break;
+    case 0x185500:
+        pal_set_erxmisc0_el1_inline(value);
+        break;
+    case 0x185520:
+        pal_set_erxmisc1_el1_inline(value);
+        break;
+    case 0x185540:
+        pal_set_erxmisc2_el1_inline(value);
+        break;
+    case 0x185560:
+        pal_set_erxmisc3_el1_inline(value);
+        break;
+    case 0x1854c0:
+        pal_set_erxpfgcdn_el1_inline(value);
+        break;
+    case 0x1854a0:
+        pal_set_erxpfgctl_el1_inline(value);
+        break;
+    case 0x185480:
+        pal_set_erxpfgf_el1_inline(value);
+        break;
+    case 0x185440:
+        pal_set_erxstatus_el1_inline(value);
+        break;
+    case 0x185200:
+        pal_set_esr_el1_inline(value);
+        break;
+    case 0x1c5200:
+        pal_set_esr_el2_inline(value);
+        break;
+    case 0x1e5200:
+        pal_set_esr_el3_inline(value);
+        break;
+    case 0x186000:
+        pal_set_far_el1_inline(value);
+        break;
+    case 0x1c6000:
+        pal_set_far_el2_inline(value);
+        break;
+    case 0x1e6000:
+        pal_set_far_el3_inline(value);
+        break;
+    case 0x1b4400:
+        pal_set_fpcr_inline(value);
+        break;
+    case 0x1c5300:
+        pal_set_fpexc32_el2_inline(value);
+        break;
+    case 0x1b4420:
+        pal_set_fpsr_inline(value);
+        break;
+    case 0x1810c0:
+        pal_set_gcr_el1_inline(value);
+        break;
+    case 0x1c11e0:
+        pal_set_hacr_el2_inline(value);
+        break;
+    case 0x1c1100:
+        pal_set_hcr_el2_inline(value);
+        break;
+    case 0x1c6080:
+        pal_set_hpfar_el2_inline(value);
+        break;
+    case 0x1c1160:
+        pal_set_hstr_el2_inline(value);
+        break;
+    case 0x18c880:
+        pal_set_icc_ap0r0_el1_inline(value);
+        break;
+    case 0x18c8a0:
+        pal_set_icc_ap0r1_el1_inline(value);
+        break;
+    case 0x18c8c0:
+        pal_set_icc_ap0r2_el1_inline(value);
+        break;
+    case 0x18c8e0:
+        pal_set_icc_ap0r3_el1_inline(value);
+        break;
+    case 0x18c900:
+        pal_set_icc_ap1r0_el1_inline(value);
+        break;
+    case 0x18c920:
+        pal_set_icc_ap1r1_el1_inline(value);
+        break;
+    case 0x18c940:
+        pal_set_icc_ap1r2_el1_inline(value);
+        break;
+    case 0x18c960:
+        pal_set_icc_ap1r3_el1_inline(value);
+        break;
+    case 0x18cbc0:
+        pal_set_icc_asgi1r_el1_inline(value);
+        break;
+    case 0x18c860:
+        pal_set_icc_bpr0_el1_inline(value);
+        break;
+    case 0x18cc60:
+        pal_set_icc_bpr1_el1_inline(value);
+        break;
+    case 0x18cc80:
+        pal_set_icc_ctlr_el1_inline(value);
+        break;
+    case 0x1ecc80:
+        pal_set_icc_ctlr_el3_inline(value);
+        break;
+    case 0x18cb20:
+        pal_set_icc_dir_el1_inline(value);
+        break;
+    case 0x18c820:
+        pal_set_icc_eoir0_el1_inline(value);
+        break;
+    case 0x18cc20:
+        pal_set_icc_eoir1_el1_inline(value);
+        break;
+    case 0x18c840:
+        pal_set_icc_hppir0_el1_inline(value);
+        break;
+    case 0x18cc40:
+        pal_set_icc_hppir1_el1_inline(value);
+        break;
+    case 0x18c800:
+        pal_set_icc_iar0_el1_inline(value);
+        break;
+    case 0x18cc00:
+        pal_set_icc_iar1_el1_inline(value);
+        break;
+    case 0x18ccc0:
+        pal_set_icc_igrpen0_el1_inline(value);
+        break;
+    case 0x18cce0:
+        pal_set_icc_igrpen1_el1_inline(value);
+        break;
+    case 0x1ecce0:
+        pal_set_icc_igrpen1_el3_inline(value);
+        break;
+    case 0x184600:
+        pal_set_icc_pmr_el1_inline(value);
+        break;
+    case 0x18cb60:
+        pal_set_icc_rpr_el1_inline(value);
+        break;
+    case 0x18cbe0:
+        pal_set_icc_sgi0r_el1_inline(value);
+        break;
+    case 0x18cba0:
+        pal_set_icc_sgi1r_el1_inline(value);
+        break;
+    case 0x18cca0:
+        pal_set_icc_sre_el1_inline(value);
+        break;
+    case 0x1cc9a0:
+        pal_set_icc_sre_el2_inline(value);
+        break;
+    case 0x1ecca0:
+        pal_set_icc_sre_el3_inline(value);
+        break;
+    case 0x1cc800:
+        pal_set_ich_ap0r0_el2_inline(value);
+        break;
+    case 0x1cc820:
+        pal_set_ich_ap0r1_el2_inline(value);
+        break;
+    case 0x1cc840:
+        pal_set_ich_ap0r2_el2_inline(value);
+        break;
+    case 0x1cc860:
+        pal_set_ich_ap0r3_el2_inline(value);
+        break;
+    case 0x1cc900:
+        pal_set_ich_ap1r0_el2_inline(value);
+        break;
+    case 0x1cc920:
+        pal_set_ich_ap1r1_el2_inline(value);
+        break;
+    case 0x1cc940:
+        pal_set_ich_ap1r2_el2_inline(value);
+        break;
+    case 0x1cc960:
+        pal_set_ich_ap1r3_el2_inline(value);
+        break;
+    case 0x1ccb60:
+        pal_set_ich_eisr_el2_inline(value);
+        break;
+    case 0x1ccba0:
+        pal_set_ich_elrsr_el2_inline(value);
+        break;
+    case 0x1ccb00:
+        pal_set_ich_hcr_el2_inline(value);
+        break;
+    case 0x1ccc00:
+        pal_set_ich_lr0_el2_inline(value);
+        break;
+    case 0x1ccd40:
+        pal_set_ich_lr10_el2_inline(value);
+        break;
+    case 0x1ccd60:
+        pal_set_ich_lr11_el2_inline(value);
+        break;
+    case 0x1ccd80:
+        pal_set_ich_lr12_el2_inline(value);
+        break;
+    case 0x1ccda0:
+        pal_set_ich_lr13_el2_inline(value);
+        break;
+    case 0x1ccdc0:
+        pal_set_ich_lr14_el2_inline(value);
+        break;
+    case 0x1ccde0:
+        pal_set_ich_lr15_el2_inline(value);
+        break;
+    case 0x1ccc20:
+        pal_set_ich_lr1_el2_inline(value);
+        break;
+    case 0x1ccc40:
+        pal_set_ich_lr2_el2_inline(value);
+        break;
+    case 0x1ccc60:
+        pal_set_ich_lr3_el2_inline(value);
+        break;
+    case 0x1ccc80:
+        pal_set_ich_lr4_el2_inline(value);
+        break;
+    case 0x1ccca0:
+        pal_set_ich_lr5_el2_inline(value);
+        break;
+    case 0x1cccc0:
+        pal_set_ich_lr6_el2_inline(value);
+        break;
+    case 0x1ccce0:
+        pal_set_ich_lr7_el2_inline(value);
+        break;
+    case 0x1ccd00:
+        pal_set_ich_lr8_el2_inline(value);
+        break;
+    case 0x1ccd20:
+        pal_set_ich_lr9_el2_inline(value);
+        break;
+    case 0x1ccb40:
+        pal_set_ich_misr_el2_inline(value);
+        break;
+    case 0x1ccbe0:
+        pal_set_ich_vmcr_el2_inline(value);
+        break;
+    case 0x1ccb20:
+        pal_set_ich_vtr_el2_inline(value);
+        break;
+    case 0x180580:
+        pal_set_id_aa64afr0_el1_inline(value);
+        break;
+    case 0x1805a0:
+        pal_set_id_aa64afr1_el1_inline(value);
+        break;
+    case 0x180500:
+        pal_set_id_aa64dfr0_el1_inline(value);
+        break;
+    case 0x180520:
+        pal_set_id_aa64dfr1_el1_inline(value);
+        break;
+    case 0x180600:
+        pal_set_id_aa64isar0_el1_inline(value);
+        break;
+    case 0x180620:
+        pal_set_id_aa64isar1_el1_inline(value);
+        break;
+    case 0x180700:
+        pal_set_id_aa64mmfr0_el1_inline(value);
+        break;
+    case 0x180720:
+        pal_set_id_aa64mmfr1_el1_inline(value);
+        break;
+    case 0x180740:
+        pal_set_id_aa64mmfr2_el1_inline(value);
+        break;
+    case 0x180400:
+        pal_set_id_aa64pfr0_el1_inline(value);
+        break;
+    case 0x180420:
+        pal_set_id_aa64pfr1_el1_inline(value);
+        break;
+    case 0x180480:
+        pal_set_id_aa64zfr0_el1_inline(value);
+        break;
+    case 0x180160:
+        pal_set_id_afr0_el1_inline(value);
+        break;
+    case 0x180140:
+        pal_set_id_dfr0_el1_inline(value);
+        break;
+    case 0x180200:
+        pal_set_id_isar0_el1_inline(value);
+        break;
+    case 0x180220:
+        pal_set_id_isar1_el1_inline(value);
+        break;
+    case 0x180240:
+        pal_set_id_isar2_el1_inline(value);
+        break;
+    case 0x180260:
+        pal_set_id_isar3_el1_inline(value);
+        break;
+    case 0x180280:
+        pal_set_id_isar4_el1_inline(value);
+        break;
+    case 0x1802a0:
+        pal_set_id_isar5_el1_inline(value);
+        break;
+    case 0x1802e0:
+        pal_set_id_isar6_el1_inline(value);
+        break;
+    case 0x180180:
+        pal_set_id_mmfr0_el1_inline(value);
+        break;
+    case 0x1801a0:
+        pal_set_id_mmfr1_el1_inline(value);
+        break;
+    case 0x1801c0:
+        pal_set_id_mmfr2_el1_inline(value);
+        break;
+    case 0x1801e0:
+        pal_set_id_mmfr3_el1_inline(value);
+        break;
+    case 0x1802c0:
+        pal_set_id_mmfr4_el1_inline(value);
+        break;
+    case 0x180100:
+        pal_set_id_pfr0_el1_inline(value);
+        break;
+    case 0x180120:
+        pal_set_id_pfr1_el1_inline(value);
+        break;
+    case 0x180380:
+        pal_set_id_pfr2_el1_inline(value);
+        break;
+    case 0x1c5020:
+        pal_set_ifsr32_el2_inline(value);
+        break;
+    case 0x18c100:
+        pal_set_isr_el1_inline(value);
+        break;
+    case 0x18a460:
+        pal_set_lorc_el1_inline(value);
+        break;
+    case 0x18a420:
+        pal_set_lorea_el1_inline(value);
+        break;
+    case 0x18a4e0:
+        pal_set_lorid_el1_inline(value);
+        break;
+    case 0x18a440:
+        pal_set_lorn_el1_inline(value);
+        break;
+    case 0x18a400:
+        pal_set_lorsa_el1_inline(value);
+        break;
+    case 0x18a200:
+        pal_set_mair_el1_inline(value);
+        break;
+    case 0x1ca200:
+        pal_set_mair_el2_inline(value);
+        break;
+    case 0x1ea200:
+        pal_set_mair_el3_inline(value);
+        break;
+    case 0x100200:
+        pal_set_mdccint_el1_inline(value);
+        break;
+    case 0x130100:
+        pal_set_mdccsr_el0_inline(value);
+        break;
+    case 0x1c1120:
+        pal_set_mdcr_el2_inline(value);
+        break;
+    case 0x1e1320:
+        pal_set_mdcr_el3_inline(value);
+        break;
+    case 0x101000:
+        pal_set_mdrar_el1_inline(value);
+        break;
+    case 0x100240:
+        pal_set_mdscr_el1_inline(value);
+        break;
+    case 0x180000:
+        pal_set_midr_el1_inline(value);
+        break;
+    case 0x18a520:
+        pal_set_mpam0_el1_inline(value);
+        break;
+    case 0x18a500:
+        pal_set_mpam1_el1_inline(value);
+        break;
+    case 0x1ca500:
+        pal_set_mpam2_el2_inline(value);
+        break;
+    case 0x1ea500:
+        pal_set_mpam3_el3_inline(value);
+        break;
+    case 0x1ca400:
+        pal_set_mpamhcr_el2_inline(value);
+        break;
+    case 0x18a480:
+        pal_set_mpamidr_el1_inline(value);
+        break;
+    case 0x1ca600:
+        pal_set_mpamvpm0_el2_inline(value);
+        break;
+    case 0x1ca620:
+        pal_set_mpamvpm1_el2_inline(value);
+        break;
+    case 0x1ca640:
+        pal_set_mpamvpm2_el2_inline(value);
+        break;
+    case 0x1ca660:
+        pal_set_mpamvpm3_el2_inline(value);
+        break;
+    case 0x1ca680:
+        pal_set_mpamvpm4_el2_inline(value);
+        break;
+    case 0x1ca6a0:
+        pal_set_mpamvpm5_el2_inline(value);
+        break;
+    case 0x1ca6c0:
+        pal_set_mpamvpm6_el2_inline(value);
+        break;
+    case 0x1ca6e0:
+        pal_set_mpamvpm7_el2_inline(value);
+        break;
+    case 0x1ca420:
+        pal_set_mpamvpmv_el2_inline(value);
+        break;
+    case 0x1800a0:
+        pal_set_mpidr_el1_inline(value);
+        break;
+    case 0x180300:
+        pal_set_mvfr0_el1_inline(value);
+        break;
+    case 0x180320:
+        pal_set_mvfr1_el1_inline(value);
+        break;
+    case 0x180340:
+        pal_set_mvfr2_el1_inline(value);
+        break;
+    case 0x1b4200:
+        pal_set_nzcv_inline(value);
+        break;
+    case 0x101380:
+        pal_set_osdlr_el1_inline(value);
+        break;
+    case 0x100040:
+        pal_set_osdtrrx_el1_inline(value);
+        break;
+    case 0x100340:
+        pal_set_osdtrtx_el1_inline(value);
+        break;
+    case 0x100640:
+        pal_set_oseccr_el1_inline(value);
+        break;
+    case 0x101080:
+        pal_set_oslar_el1_inline(value);
+        break;
+    case 0x101180:
+        pal_set_oslsr_el1_inline(value);
+        break;
+    case 0x184260:
+        pal_set_pan_inline(value);
+        break;
+    case 0x187400:
+        pal_set_par_el1_inline(value);
+        break;
+    case 0x189ae0:
+        pal_set_pmbidr_el1_inline(value);
+        break;
+    case 0x189a00:
+        pal_set_pmblimitr_el1_inline(value);
+        break;
+    case 0x189a20:
+        pal_set_pmbptr_el1_inline(value);
+        break;
+    case 0x189a60:
+        pal_set_pmbsr_el1_inline(value);
+        break;
+    case 0x1befe0:
+        pal_set_pmccfiltr_el0_inline(value);
+        break;
+    case 0x1b9d00:
+        pal_set_pmccntr_el0_inline(value);
+        break;
+    case 0x1b9cc0:
+        pal_set_pmceid0_el0_inline(value);
+        break;
+    case 0x1b9ce0:
+        pal_set_pmceid1_el0_inline(value);
+        break;
+    case 0x1b9c40:
+        pal_set_pmcntenclr_el0_inline(value);
+        break;
+    case 0x1b9c20:
+        pal_set_pmcntenset_el0_inline(value);
+        break;
+    case 0x1b9c00:
+        pal_set_pmcr_el0_inline(value);
+        break;
+    case 0x1be800:
+        pal_set_pmevcntr0_el0_inline(value);
+        break;
+    case 0x1be940:
+        pal_set_pmevcntr10_el0_inline(value);
+        break;
+    case 0x1be960:
+        pal_set_pmevcntr11_el0_inline(value);
+        break;
+    case 0x1be980:
+        pal_set_pmevcntr12_el0_inline(value);
+        break;
+    case 0x1be9a0:
+        pal_set_pmevcntr13_el0_inline(value);
+        break;
+    case 0x1be9c0:
+        pal_set_pmevcntr14_el0_inline(value);
+        break;
+    case 0x1be9e0:
+        pal_set_pmevcntr15_el0_inline(value);
+        break;
+    case 0x1bea00:
+        pal_set_pmevcntr16_el0_inline(value);
+        break;
+    case 0x1bea20:
+        pal_set_pmevcntr17_el0_inline(value);
+        break;
+    case 0x1bea40:
+        pal_set_pmevcntr18_el0_inline(value);
+        break;
+    case 0x1bea60:
+        pal_set_pmevcntr19_el0_inline(value);
+        break;
+    case 0x1be820:
+        pal_set_pmevcntr1_el0_inline(value);
+        break;
+    case 0x1bea80:
+        pal_set_pmevcntr20_el0_inline(value);
+        break;
+    case 0x1beaa0:
+        pal_set_pmevcntr21_el0_inline(value);
+        break;
+    case 0x1beac0:
+        pal_set_pmevcntr22_el0_inline(value);
+        break;
+    case 0x1beae0:
+        pal_set_pmevcntr23_el0_inline(value);
+        break;
+    case 0x1beb00:
+        pal_set_pmevcntr24_el0_inline(value);
+        break;
+    case 0x1beb20:
+        pal_set_pmevcntr25_el0_inline(value);
+        break;
+    case 0x1beb40:
+        pal_set_pmevcntr26_el0_inline(value);
+        break;
+    case 0x1beb60:
+        pal_set_pmevcntr27_el0_inline(value);
+        break;
+    case 0x1beb80:
+        pal_set_pmevcntr28_el0_inline(value);
+        break;
+    case 0x1beba0:
+        pal_set_pmevcntr29_el0_inline(value);
+        break;
+    case 0x1be840:
+        pal_set_pmevcntr2_el0_inline(value);
+        break;
+    case 0x1bebc0:
+        pal_set_pmevcntr30_el0_inline(value);
+        break;
+    case 0x1be860:
+        pal_set_pmevcntr3_el0_inline(value);
+        break;
+    case 0x1be880:
+        pal_set_pmevcntr4_el0_inline(value);
+        break;
+    case 0x1be8a0:
+        pal_set_pmevcntr5_el0_inline(value);
+        break;
+    case 0x1be8c0:
+        pal_set_pmevcntr6_el0_inline(value);
+        break;
+    case 0x1be8e0:
+        pal_set_pmevcntr7_el0_inline(value);
+        break;
+    case 0x1be900:
+        pal_set_pmevcntr8_el0_inline(value);
+        break;
+    case 0x1be920:
+        pal_set_pmevcntr9_el0_inline(value);
+        break;
+    case 0x1bec00:
+        pal_set_pmevtyper0_el0_inline(value);
+        break;
+    case 0x1bed40:
+        pal_set_pmevtyper10_el0_inline(value);
+        break;
+    case 0x1bed60:
+        pal_set_pmevtyper11_el0_inline(value);
+        break;
+    case 0x1bed80:
+        pal_set_pmevtyper12_el0_inline(value);
+        break;
+    case 0x1beda0:
+        pal_set_pmevtyper13_el0_inline(value);
+        break;
+    case 0x1bedc0:
+        pal_set_pmevtyper14_el0_inline(value);
+        break;
+    case 0x1bede0:
+        pal_set_pmevtyper15_el0_inline(value);
+        break;
+    case 0x1bee00:
+        pal_set_pmevtyper16_el0_inline(value);
+        break;
+    case 0x1bee20:
+        pal_set_pmevtyper17_el0_inline(value);
+        break;
+    case 0x1bee40:
+        pal_set_pmevtyper18_el0_inline(value);
+        break;
+    case 0x1bee60:
+        pal_set_pmevtyper19_el0_inline(value);
+        break;
+    case 0x1bec20:
+        pal_set_pmevtyper1_el0_inline(value);
+        break;
+    case 0x1bee80:
+        pal_set_pmevtyper20_el0_inline(value);
+        break;
+    case 0x1beea0:
+        pal_set_pmevtyper21_el0_inline(value);
+        break;
+    case 0x1beec0:
+        pal_set_pmevtyper22_el0_inline(value);
+        break;
+    case 0x1beee0:
+        pal_set_pmevtyper23_el0_inline(value);
+        break;
+    case 0x1bef00:
+        pal_set_pmevtyper24_el0_inline(value);
+        break;
+    case 0x1bef20:
+        pal_set_pmevtyper25_el0_inline(value);
+        break;
+    case 0x1bef40:
+        pal_set_pmevtyper26_el0_inline(value);
+        break;
+    case 0x1bef60:
+        pal_set_pmevtyper27_el0_inline(value);
+        break;
+    case 0x1bef80:
+        pal_set_pmevtyper28_el0_inline(value);
+        break;
+    case 0x1befa0:
+        pal_set_pmevtyper29_el0_inline(value);
+        break;
+    case 0x1bec40:
+        pal_set_pmevtyper2_el0_inline(value);
+        break;
+    case 0x1befc0:
+        pal_set_pmevtyper30_el0_inline(value);
+        break;
+    case 0x1bec60:
+        pal_set_pmevtyper3_el0_inline(value);
+        break;
+    case 0x1bec80:
+        pal_set_pmevtyper4_el0_inline(value);
+        break;
+    case 0x1beca0:
+        pal_set_pmevtyper5_el0_inline(value);
+        break;
+    case 0x1becc0:
+        pal_set_pmevtyper6_el0_inline(value);
+        break;
+    case 0x1bece0:
+        pal_set_pmevtyper7_el0_inline(value);
+        break;
+    case 0x1bed00:
+        pal_set_pmevtyper8_el0_inline(value);
+        break;
+    case 0x1bed20:
+        pal_set_pmevtyper9_el0_inline(value);
+        break;
+    case 0x189e40:
+        pal_set_pmintenclr_el1_inline(value);
+        break;
+    case 0x189e20:
+        pal_set_pmintenset_el1_inline(value);
+        break;
+    case 0x189ec0:
+        pal_set_pmmir_el1_inline(value);
+        break;
+    case 0x1b9c60:
+        pal_set_pmovsclr_el0_inline(value);
+        break;
+    case 0x1b9e60:
+        pal_set_pmovsset_el0_inline(value);
+        break;
+    case 0x189900:
+        pal_set_pmscr_el1_inline(value);
+        break;
+    case 0x1c9900:
+        pal_set_pmscr_el2_inline(value);
+        break;
+    case 0x1b9ca0:
+        pal_set_pmselr_el0_inline(value);
+        break;
+    case 0x1899a0:
+        pal_set_pmsevfr_el1_inline(value);
+        break;
+    case 0x189980:
+        pal_set_pmsfcr_el1_inline(value);
+        break;
+    case 0x189940:
+        pal_set_pmsicr_el1_inline(value);
+        break;
+    case 0x1899e0:
+        pal_set_pmsidr_el1_inline(value);
+        break;
+    case 0x189960:
+        pal_set_pmsirr_el1_inline(value);
+        break;
+    case 0x1899c0:
+        pal_set_pmslatfr_el1_inline(value);
+        break;
+    case 0x1b9c80:
+        pal_set_pmswinc_el0_inline(value);
+        break;
+    case 0x1b9e00:
+        pal_set_pmuserenr_el0_inline(value);
+        break;
+    case 0x1b9d40:
+        pal_set_pmxevcntr_el0_inline(value);
+        break;
+    case 0x1b9d20:
+        pal_set_pmxevtyper_el0_inline(value);
+        break;
+    case 0x1800c0:
+        pal_set_revidr_el1_inline(value);
+        break;
+    case 0x1810a0:
+        pal_set_rgsr_el1_inline(value);
+        break;
+    case 0x18c040:
+        pal_set_rmr_el1_inline(value);
+        break;
+    case 0x1cc040:
+        pal_set_rmr_el2_inline(value);
+        break;
+    case 0x1ec040:
+        pal_set_rmr_el3_inline(value);
+        break;
+    case 0x1b2400:
+        pal_set_rndr_inline(value);
+        break;
+    case 0x1b2420:
+        pal_set_rndrrs_inline(value);
+        break;
+    case 0x18c020:
+        pal_set_rvbar_el1_inline(value);
+        break;
+    case 0x1cc020:
+        pal_set_rvbar_el2_inline(value);
+        break;
+    case 0x1ec020:
+        pal_set_rvbar_el3_inline(value);
+        break;
+    case 0x1e1100:
+        pal_set_scr_el3_inline(value);
+        break;
+    case 0x181000:
+        pal_set_sctlr_el1_inline(value);
+        break;
+    case 0x1c1000:
+        pal_set_sctlr_el2_inline(value);
+        break;
+    case 0x1e1000:
+        pal_set_sctlr_el3_inline(value);
+        break;
+    case 0x1bd0e0:
+        pal_set_scxtnum_el0_inline(value);
+        break;
+    case 0x18d0e0:
+        pal_set_scxtnum_el1_inline(value);
+        break;
+    case 0x1cd0e0:
+        pal_set_scxtnum_el2_inline(value);
+        break;
+    case 0x1ed0e0:
+        pal_set_scxtnum_el3_inline(value);
+        break;
+    case 0x1c1320:
+        pal_set_sder32_el2_inline(value);
+        break;
+    case 0x1e1120:
+        pal_set_sder32_el3_inline(value);
+        break;
+    case 0x184100:
+        pal_set_sp_el0_inline(value);
+        break;
+    case 0x1c4100:
+        pal_set_sp_el1_inline(value);
+        break;
+    case 0x1e4100:
+        pal_set_sp_el2_inline(value);
+        break;
+    case 0x184200:
+        pal_set_spsel_inline(value);
+        break;
+    case 0x1c4320:
+        pal_set_spsr_abt_inline(value);
+        break;
+    case 0x184000:
+        pal_set_spsr_el1_inline(value);
+        break;
+    case 0x1c4000:
+        pal_set_spsr_el2_inline(value);
+        break;
+    case 0x1e4000:
+        pal_set_spsr_el3_inline(value);
+        break;
+    case 0x1c4360:
+        pal_set_spsr_fiq_inline(value);
+        break;
+    case 0x1c4300:
+        pal_set_spsr_irq_inline(value);
+        break;
+    case 0x1c4340:
+        pal_set_spsr_und_inline(value);
+        break;
+    case 0x1b42c0:
+        pal_set_ssbs_inline(value);
+        break;
+    case 0x1b42e0:
+        pal_set_tco_inline(value);
+        break;
+    case 0x182040:
+        pal_set_tcr_el1_inline(value);
+        break;
+    case 0x1c2040:
+        pal_set_tcr_el2_inline(value);
+        break;
+    case 0x1e2040:
+        pal_set_tcr_el3_inline(value);
+        break;
+    case 0x186500:
+        pal_set_tfsr_el1_inline(value);
+        break;
+    case 0x1c6500:
+        pal_set_tfsr_el2_inline(value);
+        break;
+    case 0x1e6500:
+        pal_set_tfsr_el3_inline(value);
+        break;
+    case 0x186620:
+        pal_set_tfsre0_el1_inline(value);
+        break;
+    case 0x1bd040:
+        pal_set_tpidr_el0_inline(value);
+        break;
+    case 0x18d080:
+        pal_set_tpidr_el1_inline(value);
+        break;
+    case 0x1cd040:
+        pal_set_tpidr_el2_inline(value);
+        break;
+    case 0x1ed040:
+        pal_set_tpidr_el3_inline(value);
+        break;
+    case 0x1bd060:
+        pal_set_tpidrro_el0_inline(value);
+        break;
+    case 0x181220:
+        pal_set_trfcr_el1_inline(value);
+        break;
+    case 0x1c1220:
+        pal_set_trfcr_el2_inline(value);
+        break;
+    case 0x182000:
+        pal_set_ttbr0_el1_inline(value);
+        break;
+    case 0x1c2000:
+        pal_set_ttbr0_el2_inline(value);
+        break;
+    case 0x1e2000:
+        pal_set_ttbr0_el3_inline(value);
+        break;
+    case 0x182020:
+        pal_set_ttbr1_el1_inline(value);
+        break;
+    case 0x1c2020:
+        pal_set_ttbr1_el2_inline(value);
+        break;
+    case 0x184280:
+        pal_set_uao_inline(value);
+        break;
+    case 0x18c000:
+        pal_set_vbar_el1_inline(value);
+        break;
+    case 0x1cc000:
+        pal_set_vbar_el2_inline(value);
+        break;
+    case 0x1ec000:
+        pal_set_vbar_el3_inline(value);
+        break;
+    case 0x1cc120:
+        pal_set_vdisr_el2_inline(value);
+        break;
+    case 0x1c2200:
+        pal_set_vncr_el2_inline(value);
+        break;
+    case 0x1c5260:
+        pal_set_vsesr_el2_inline(value);
+        break;
+    case 0x1c2640:
+        pal_set_vstcr_el2_inline(value);
+        break;
+    case 0x1c2600:
+        pal_set_vsttbr_el2_inline(value);
+        break;
+    case 0x1c2140:
+        pal_set_vtcr_el2_inline(value);
+        break;
+    case 0x1c2100:
+        pal_set_vttbr_el2_inline(value);
+        break;
+    case 0x181200:
+        pal_set_zcr_el1_inline(value);
+        break;
+    case 0x1c1200:
+        pal_set_zcr_el2_inline(value);
+        break;
+    case 0x1e1200:
+        pal_set_zcr_el3_inline(value);
+        break;
+    default:
+        printk(KERN_INFO "Defualt case!");
+        return -EINVAL;
+        break;
+    }
 
 
     return 0;

--- a/devpal/linux/armv8a/aarch64/sysl.c
+++ b/devpal/linux/armv8a/aarch64/sysl.c
@@ -1,8 +1,10 @@
 #include <linux/uaccess.h>
 #include "devpal_abi_armv8a_aarch64.h"
+#include <linux/printk.h>
 
 long handle_devpal_ioctl_sysl(struct sysl_operands * user_ops)
 {
+    //Init of variables/operands 
     uint8_t op1 = 0;
     uint8_t crn = 0;
     uint8_t crm = 0;
@@ -18,10 +20,10 @@ long handle_devpal_ioctl_sysl(struct sysl_operands * user_ops)
     crm = kern_ops.in.crm;
     op2 = kern_ops.in.op2;
 
-    // TODO: Implement Me!
-    //  - take the fields that make up the encoding for the A64 SYS instruction
-    //  - calculate the instruction encoding
-    //  - map the encoding to a function implemented within the driver
+    //inline assembly for mrs
+    __asm__ volatile("mrs %0, s3_0_c1_c0_0"
+                   : "=r"(value));
+
 
     kern_ops.out.value = value;
     if (copy_to_user(user_ops, &kern_ops, sizeof(struct sysl_operands)))

--- a/devpal/linux/armv8a/aarch64/sysl.c
+++ b/devpal/linux/armv8a/aarch64/sysl.c
@@ -6,11 +6,13 @@
 long handle_devpal_ioctl_sysl(struct sysl_operands * user_ops)
 {
     //Init of variables/operands 
+    uint8_t op0 = 0;
     uint8_t op1 = 0;
     uint8_t crn = 0;
     uint8_t crm = 0;
     uint8_t op2 = 0;
     uint64_t value = 0;
+    uint32_t switch_vector = 0;
     struct sysl_operands kern_ops = {0};
 
     if (copy_from_user(&kern_ops, user_ops, sizeof(struct sysl_operands)))

--- a/devpal/linux/armv8a/aarch64/sysl.c
+++ b/devpal/linux/armv8a/aarch64/sysl.c
@@ -1,6 +1,7 @@
 #include <linux/uaccess.h>
 #include "devpal_abi_armv8a_aarch64.h"
 #include <linux/printk.h>
+#include "pal/aarch64/sysl_inline.h"
 
 long handle_devpal_ioctl_sysl(struct sysl_operands * user_ops)
 {
@@ -15,16 +16,1607 @@ long handle_devpal_ioctl_sysl(struct sysl_operands * user_ops)
     if (copy_from_user(&kern_ops, user_ops, sizeof(struct sysl_operands)))
         return -1;
 
+    op0 = kern_ops.in.op0;
     op1 = kern_ops.in.op1;
     crn = kern_ops.in.crn;
     crm = kern_ops.in.crm;
     op2 = kern_ops.in.op2;
 
-    //inline assembly for mrs
-    __asm__ volatile("mrs %0, s3_0_c1_c0_0"
-                   : "=r"(value));
+    //The switch vector the sys/sysl instruction encodin, the last 5 bits are not used for our purposes
+    switch_vector |= (op0 & 0x3) << 19;
+    switch_vector |= (op1 & 0x7) << 16;
+    switch_vector |= (crn & 0xF) << 12;
+    switch_vector |= (crm & 0xF) << 8;
+    switch_vector |= (op2 & 0x7) << 5;
 
+    //printk(KERN_INFO "operands: %x, %x, %x, %x, %x\n", op0, op1, crn, crm, op2);
+    //printk(KERN_INFO "vector hex: %x", switch_vector);
 
+    switch (switch_vector)
+    {
+    case 0x181020:
+        value = pal_get_actlr_el1_inline();
+        break;
+    case 0x1c1020:
+        value = pal_get_actlr_el2_inline();
+        break;
+    case 0x1e1020:
+        value = pal_get_actlr_el3_inline();
+        break;
+    case 0x185100:
+        value = pal_get_afsr0_el1_inline();
+        break;
+    case 0x1c5100:
+        value = pal_get_afsr0_el2_inline();
+        break;
+    case 0x1e5100:
+        value = pal_get_afsr0_el3_inline();
+        break;
+    case 0x185120:
+        value = pal_get_afsr1_el1_inline();
+        break;
+    case 0x1c5120:
+        value = pal_get_afsr1_el2_inline();
+        break;
+    case 0x1e5120:
+        value = pal_get_afsr1_el3_inline();
+        break;
+    case 0x1900e0:
+        value = pal_get_aidr_el1_inline();
+        break;
+    case 0x18a300:
+        value = pal_get_amair_el1_inline();
+        break;
+    case 0x1ca300:
+        value = pal_get_amair_el2_inline();
+        break;
+    case 0x1ea300:
+        value = pal_get_amair_el3_inline();
+        break;
+    case 0x1bd220:
+        value = pal_get_amcfgr_el0_inline();
+        break;
+    case 0x1bd240:
+        value = pal_get_amcgcr_el0_inline();
+        break;
+    case 0x1bd280:
+        value = pal_get_amcntenclr0_el0_inline();
+        break;
+    case 0x1bd300:
+        value = pal_get_amcntenclr1_el0_inline();
+        break;
+    case 0x1bd2a0:
+        value = pal_get_amcntenset0_el0_inline();
+        break;
+    case 0x1bd320:
+        value = pal_get_amcntenset1_el0_inline();
+        break;
+    case 0x1bd200:
+        value = pal_get_amcr_el0_inline();
+        break;
+    case 0x1bd400:
+        value = pal_get_amevcntr00_el0_inline();
+        break;
+    case 0x1bd540:
+        value = pal_get_amevcntr010_el0_inline();
+        break;
+    case 0x1bd560:
+        value = pal_get_amevcntr011_el0_inline();
+        break;
+    case 0x1bd580:
+        value = pal_get_amevcntr012_el0_inline();
+        break;
+    case 0x1bd5a0:
+        value = pal_get_amevcntr013_el0_inline();
+        break;
+    case 0x1bd5c0:
+        value = pal_get_amevcntr014_el0_inline();
+        break;
+    case 0x1bd5e0:
+        value = pal_get_amevcntr015_el0_inline();
+        break;
+    case 0x1bd420:
+        value = pal_get_amevcntr01_el0_inline();
+        break;
+    case 0x1bd440:
+        value = pal_get_amevcntr02_el0_inline();
+        break;
+    case 0x1bd460:
+        value = pal_get_amevcntr03_el0_inline();
+        break;
+    case 0x1bd480:
+        value = pal_get_amevcntr04_el0_inline();
+        break;
+    case 0x1bd4a0:
+        value = pal_get_amevcntr05_el0_inline();
+        break;
+    case 0x1bd4c0:
+        value = pal_get_amevcntr06_el0_inline();
+        break;
+    case 0x1bd4e0:
+        value = pal_get_amevcntr07_el0_inline();
+        break;
+    case 0x1bd500:
+        value = pal_get_amevcntr08_el0_inline();
+        break;
+    case 0x1bd520:
+        value = pal_get_amevcntr09_el0_inline();
+        break;
+    case 0x1bdc00:
+        value = pal_get_amevcntr10_el0_inline();
+        break;
+    case 0x1bdd40:
+        value = pal_get_amevcntr110_el0_inline();
+        break;
+    case 0x1bdd60:
+        value = pal_get_amevcntr111_el0_inline();
+        break;
+    case 0x1bdd80:
+        value = pal_get_amevcntr112_el0_inline();
+        break;
+    case 0x1bdda0:
+        value = pal_get_amevcntr113_el0_inline();
+        break;
+    case 0x1bddc0:
+        value = pal_get_amevcntr114_el0_inline();
+        break;
+    case 0x1bdde0:
+        value = pal_get_amevcntr115_el0_inline();
+        break;
+    case 0x1bdc20:
+        value = pal_get_amevcntr11_el0_inline();
+        break;
+    case 0x1bdc40:
+        value = pal_get_amevcntr12_el0_inline();
+        break;
+    case 0x1bdc60:
+        value = pal_get_amevcntr13_el0_inline();
+        break;
+    case 0x1bdc80:
+        value = pal_get_amevcntr14_el0_inline();
+        break;
+    case 0x1bdca0:
+        value = pal_get_amevcntr15_el0_inline();
+        break;
+    case 0x1bdcc0:
+        value = pal_get_amevcntr16_el0_inline();
+        break;
+    case 0x1bdce0:
+        value = pal_get_amevcntr17_el0_inline();
+        break;
+    case 0x1bdd00:
+        value = pal_get_amevcntr18_el0_inline();
+        break;
+    case 0x1bdd20:
+        value = pal_get_amevcntr19_el0_inline();
+        break;
+    case 0x1bd600:
+        value = pal_get_amevtyper00_el0_inline();
+        break;
+    case 0x1bd740:
+        value = pal_get_amevtyper010_el0_inline();
+        break;
+    case 0x1bd760:
+        value = pal_get_amevtyper011_el0_inline();
+        break;
+    case 0x1bd780:
+        value = pal_get_amevtyper012_el0_inline();
+        break;
+    case 0x1bd7a0:
+        value = pal_get_amevtyper013_el0_inline();
+        break;
+    case 0x1bd7c0:
+        value = pal_get_amevtyper014_el0_inline();
+        break;
+    case 0x1bd7e0:
+        value = pal_get_amevtyper015_el0_inline();
+        break;
+    case 0x1bd620:
+        value = pal_get_amevtyper01_el0_inline();
+        break;
+    case 0x1bd640:
+        value = pal_get_amevtyper02_el0_inline();
+        break;
+    case 0x1bd660:
+        value = pal_get_amevtyper03_el0_inline();
+        break;
+    case 0x1bd680:
+        value = pal_get_amevtyper04_el0_inline();
+        break;
+    case 0x1bd6a0:
+        value = pal_get_amevtyper05_el0_inline();
+        break;
+    case 0x1bd6c0:
+        value = pal_get_amevtyper06_el0_inline();
+        break;
+    case 0x1bd6e0:
+        value = pal_get_amevtyper07_el0_inline();
+        break;
+    case 0x1bd700:
+        value = pal_get_amevtyper08_el0_inline();
+        break;
+    case 0x1bd720:
+        value = pal_get_amevtyper09_el0_inline();
+        break;
+    case 0x1bde00:
+        value = pal_get_amevtyper10_el0_inline();
+        break;
+    case 0x1bdf40:
+        value = pal_get_amevtyper110_el0_inline();
+        break;
+    case 0x1bdf60:
+        value = pal_get_amevtyper111_el0_inline();
+        break;
+    case 0x1bdf80:
+        value = pal_get_amevtyper112_el0_inline();
+        break;
+    case 0x1bdfa0:
+        value = pal_get_amevtyper113_el0_inline();
+        break;
+    case 0x1bdfc0:
+        value = pal_get_amevtyper114_el0_inline();
+        break;
+    case 0x1bdfe0:
+        value = pal_get_amevtyper115_el0_inline();
+        break;
+    case 0x1bde20:
+        value = pal_get_amevtyper11_el0_inline();
+        break;
+    case 0x1bde40:
+        value = pal_get_amevtyper12_el0_inline();
+        break;
+    case 0x1bde60:
+        value = pal_get_amevtyper13_el0_inline();
+        break;
+    case 0x1bde80:
+        value = pal_get_amevtyper14_el0_inline();
+        break;
+    case 0x1bdea0:
+        value = pal_get_amevtyper15_el0_inline();
+        break;
+    case 0x1bdec0:
+        value = pal_get_amevtyper16_el0_inline();
+        break;
+    case 0x1bdee0:
+        value = pal_get_amevtyper17_el0_inline();
+        break;
+    case 0x1bdf00:
+        value = pal_get_amevtyper18_el0_inline();
+        break;
+    case 0x1bdf20:
+        value = pal_get_amevtyper19_el0_inline();
+        break;
+    case 0x1bd260:
+        value = pal_get_amuserenr_el0_inline();
+        break;
+    case 0x182220:
+        value = pal_get_apdakeyhi_el1_inline();
+        break;
+    case 0x182200:
+        value = pal_get_apdakeylo_el1_inline();
+        break;
+    case 0x182260:
+        value = pal_get_apdbkeyhi_el1_inline();
+        break;
+    case 0x182240:
+        value = pal_get_apdbkeylo_el1_inline();
+        break;
+    case 0x182320:
+        value = pal_get_apgakeyhi_el1_inline();
+        break;
+    case 0x182300:
+        value = pal_get_apgakeylo_el1_inline();
+        break;
+    case 0x182120:
+        value = pal_get_apiakeyhi_el1_inline();
+        break;
+    case 0x182100:
+        value = pal_get_apiakeylo_el1_inline();
+        break;
+    case 0x182160:
+        value = pal_get_apibkeyhi_el1_inline();
+        break;
+    case 0x182140:
+        value = pal_get_apibkeylo_el1_inline();
+        break;
+    case 0x190040:
+        value = pal_get_ccsidr2_el1_inline();
+        break;
+    case 0x190000:
+        value = pal_get_ccsidr_el1_inline();
+        break;
+    case 0x190020:
+        value = pal_get_clidr_el1_inline();
+        break;
+    case 0x1be000:
+        value = pal_get_cntfrq_el0_inline();
+        break;
+    case 0x1ce100:
+        value = pal_get_cnthctl_el2_inline();
+        break;
+    case 0x1ce220:
+        value = pal_get_cnthp_ctl_el2_inline();
+        break;
+    case 0x1ce240:
+        value = pal_get_cnthp_cval_el2_inline();
+        break;
+    case 0x1ce200:
+        value = pal_get_cnthp_tval_el2_inline();
+        break;
+    case 0x1ce520:
+        value = pal_get_cnthps_ctl_el2_inline();
+        break;
+    case 0x1ce540:
+        value = pal_get_cnthps_cval_el2_inline();
+        break;
+    case 0x1ce500:
+        value = pal_get_cnthps_tval_el2_inline();
+        break;
+    case 0x1ce320:
+        value = pal_get_cnthv_ctl_el2_inline();
+        break;
+    case 0x1ce340:
+        value = pal_get_cnthv_cval_el2_inline();
+        break;
+    case 0x1ce300:
+        value = pal_get_cnthv_tval_el2_inline();
+        break;
+    case 0x1ce420:
+        value = pal_get_cnthvs_ctl_el2_inline();
+        break;
+    case 0x1ce440:
+        value = pal_get_cnthvs_cval_el2_inline();
+        break;
+    case 0x1ce400:
+        value = pal_get_cnthvs_tval_el2_inline();
+        break;
+    case 0x18e100:
+        value = pal_get_cntkctl_el1_inline();
+        break;
+    case 0x1be220:
+        value = pal_get_cntp_ctl_el0_inline();
+        break;
+    case 0x1be240:
+        value = pal_get_cntp_cval_el0_inline();
+        break;
+    case 0x1be200:
+        value = pal_get_cntp_tval_el0_inline();
+        break;
+    case 0x1be020:
+        value = pal_get_cntpct_el0_inline();
+        break;
+    case 0x1fe220:
+        value = pal_get_cntps_ctl_el1_inline();
+        break;
+    case 0x1fe240:
+        value = pal_get_cntps_cval_el1_inline();
+        break;
+    case 0x1fe200:
+        value = pal_get_cntps_tval_el1_inline();
+        break;
+    case 0x1be320:
+        value = pal_get_cntv_ctl_el0_inline();
+        break;
+    case 0x1be340:
+        value = pal_get_cntv_cval_el0_inline();
+        break;
+    case 0x1be300:
+        value = pal_get_cntv_tval_el0_inline();
+        break;
+    case 0x1be040:
+        value = pal_get_cntvct_el0_inline();
+        break;
+    case 0x1ce060:
+        value = pal_get_cntvoff_el2_inline();
+        break;
+    case 0x18d020:
+        value = pal_get_contextidr_el1_inline();
+        break;
+    case 0x1cd020:
+        value = pal_get_contextidr_el2_inline();
+        break;
+    case 0x181040:
+        value = pal_get_cpacr_el1_inline();
+        break;
+    case 0x1c1140:
+        value = pal_get_cptr_el2_inline();
+        break;
+    case 0x1e1140:
+        value = pal_get_cptr_el3_inline();
+        break;
+    case 0x1a0000:
+        value = pal_get_csselr_el1_inline();
+        break;
+    case 0x1b0020:
+        value = pal_get_ctr_el0_inline();
+        break;
+    case 0x184240:
+        value = pal_get_currentel_inline();
+        break;
+    case 0x1c3000:
+        value = pal_get_dacr32_el2_inline();
+        break;
+    case 0x1b4220:
+        value = pal_get_daif_inline();
+        break;
+    case 0x107ec0:
+        value = pal_get_dbgauthstatus_el1_inline();
+        break;
+    case 0x1000a0:
+        value = pal_get_dbgbcr0_el1_inline();
+        break;
+    case 0x100aa0:
+        value = pal_get_dbgbcr10_el1_inline();
+        break;
+    case 0x100ba0:
+        value = pal_get_dbgbcr11_el1_inline();
+        break;
+    case 0x100ca0:
+        value = pal_get_dbgbcr12_el1_inline();
+        break;
+    case 0x100da0:
+        value = pal_get_dbgbcr13_el1_inline();
+        break;
+    case 0x100ea0:
+        value = pal_get_dbgbcr14_el1_inline();
+        break;
+    case 0x100fa0:
+        value = pal_get_dbgbcr15_el1_inline();
+        break;
+    case 0x1001a0:
+        value = pal_get_dbgbcr1_el1_inline();
+        break;
+    case 0x1002a0:
+        value = pal_get_dbgbcr2_el1_inline();
+        break;
+    case 0x1003a0:
+        value = pal_get_dbgbcr3_el1_inline();
+        break;
+    case 0x1004a0:
+        value = pal_get_dbgbcr4_el1_inline();
+        break;
+    case 0x1005a0:
+        value = pal_get_dbgbcr5_el1_inline();
+        break;
+    case 0x1006a0:
+        value = pal_get_dbgbcr6_el1_inline();
+        break;
+    case 0x1007a0:
+        value = pal_get_dbgbcr7_el1_inline();
+        break;
+    case 0x1008a0:
+        value = pal_get_dbgbcr8_el1_inline();
+        break;
+    case 0x1009a0:
+        value = pal_get_dbgbcr9_el1_inline();
+        break;
+    case 0x100080:
+        value = pal_get_dbgbvr0_el1_inline();
+        break;
+    case 0x100a80:
+        value = pal_get_dbgbvr10_el1_inline();
+        break;
+    case 0x100b80:
+        value = pal_get_dbgbvr11_el1_inline();
+        break;
+    case 0x100c80:
+        value = pal_get_dbgbvr12_el1_inline();
+        break;
+    case 0x100d80:
+        value = pal_get_dbgbvr13_el1_inline();
+        break;
+    case 0x100e80:
+        value = pal_get_dbgbvr14_el1_inline();
+        break;
+    case 0x100f80:
+        value = pal_get_dbgbvr15_el1_inline();
+        break;
+    case 0x100180:
+        value = pal_get_dbgbvr1_el1_inline();
+        break;
+    case 0x100280:
+        value = pal_get_dbgbvr2_el1_inline();
+        break;
+    case 0x100380:
+        value = pal_get_dbgbvr3_el1_inline();
+        break;
+    case 0x100480:
+        value = pal_get_dbgbvr4_el1_inline();
+        break;
+    case 0x100580:
+        value = pal_get_dbgbvr5_el1_inline();
+        break;
+    case 0x100680:
+        value = pal_get_dbgbvr6_el1_inline();
+        break;
+    case 0x100780:
+        value = pal_get_dbgbvr7_el1_inline();
+        break;
+    case 0x100880:
+        value = pal_get_dbgbvr8_el1_inline();
+        break;
+    case 0x100980:
+        value = pal_get_dbgbvr9_el1_inline();
+        break;
+    case 0x1079c0:
+        value = pal_get_dbgclaimclr_el1_inline();
+        break;
+    case 0x1078c0:
+        value = pal_get_dbgclaimset_el1_inline();
+        break;
+    case 0x130400:
+        value = pal_get_dbgdtr_el0_inline();
+        break;
+    case 0x130500:
+        value = pal_get_dbgdtrrx_el0_inline();
+        break;
+    case 0x101480:
+        value = pal_get_dbgprcr_el1_inline();
+        break;
+    case 0x140700:
+        value = pal_get_dbgvcr32_el2_inline();
+        break;
+    case 0x1000e0:
+        value = pal_get_dbgwcr0_el1_inline();
+        break;
+    case 0x100ae0:
+        value = pal_get_dbgwcr10_el1_inline();
+        break;
+    case 0x100be0:
+        value = pal_get_dbgwcr11_el1_inline();
+        break;
+    case 0x100ce0:
+        value = pal_get_dbgwcr12_el1_inline();
+        break;
+    case 0x100de0:
+        value = pal_get_dbgwcr13_el1_inline();
+        break;
+    case 0x100ee0:
+        value = pal_get_dbgwcr14_el1_inline();
+        break;
+    case 0x100fe0:
+        value = pal_get_dbgwcr15_el1_inline();
+        break;
+    case 0x1001e0:
+        value = pal_get_dbgwcr1_el1_inline();
+        break;
+    case 0x1002e0:
+        value = pal_get_dbgwcr2_el1_inline();
+        break;
+    case 0x1003e0:
+        value = pal_get_dbgwcr3_el1_inline();
+        break;
+    case 0x1004e0:
+        value = pal_get_dbgwcr4_el1_inline();
+        break;
+    case 0x1005e0:
+        value = pal_get_dbgwcr5_el1_inline();
+        break;
+    case 0x1006e0:
+        value = pal_get_dbgwcr6_el1_inline();
+        break;
+    case 0x1007e0:
+        value = pal_get_dbgwcr7_el1_inline();
+        break;
+    case 0x1008e0:
+        value = pal_get_dbgwcr8_el1_inline();
+        break;
+    case 0x1009e0:
+        value = pal_get_dbgwcr9_el1_inline();
+        break;
+    case 0x1000c0:
+        value = pal_get_dbgwvr0_el1_inline();
+        break;
+    case 0x100ac0:
+        value = pal_get_dbgwvr10_el1_inline();
+        break;
+    case 0x100bc0:
+        value = pal_get_dbgwvr11_el1_inline();
+        break;
+    case 0x100cc0:
+        value = pal_get_dbgwvr12_el1_inline();
+        break;
+    case 0x100dc0:
+        value = pal_get_dbgwvr13_el1_inline();
+        break;
+    case 0x100ec0:
+        value = pal_get_dbgwvr14_el1_inline();
+        break;
+    case 0x100fc0:
+        value = pal_get_dbgwvr15_el1_inline();
+        break;
+    case 0x1001c0:
+        value = pal_get_dbgwvr1_el1_inline();
+        break;
+    case 0x1002c0:
+        value = pal_get_dbgwvr2_el1_inline();
+        break;
+    case 0x1003c0:
+        value = pal_get_dbgwvr3_el1_inline();
+        break;
+    case 0x1004c0:
+        value = pal_get_dbgwvr4_el1_inline();
+        break;
+    case 0x1005c0:
+        value = pal_get_dbgwvr5_el1_inline();
+        break;
+    case 0x1006c0:
+        value = pal_get_dbgwvr6_el1_inline();
+        break;
+    case 0x1007c0:
+        value = pal_get_dbgwvr7_el1_inline();
+        break;
+    case 0x1008c0:
+        value = pal_get_dbgwvr8_el1_inline();
+        break;
+    case 0x1009c0:
+        value = pal_get_dbgwvr9_el1_inline();
+        break;
+    case 0x1b00e0:
+        value = pal_get_dczid_el0_inline();
+        break;
+    case 0x18c120:
+        value = pal_get_disr_el1_inline();
+        break;
+    case 0x1b42a0:
+        value = pal_get_dit_inline();
+        break;
+    case 0x1b4520:
+        value = pal_get_dlr_el0_inline();
+        break;
+    case 0x1b4500:
+        value = pal_get_dspsr_el0_inline();
+        break;
+    case 0x184020:
+        value = pal_get_elr_el1_inline();
+        break;
+    case 0x1c4020:
+        value = pal_get_elr_el2_inline();
+        break;
+    case 0x1e4020:
+        value = pal_get_elr_el3_inline();
+        break;
+    case 0x185300:
+        value = pal_get_erridr_el1_inline();
+        break;
+    case 0x185320:
+        value = pal_get_errselr_el1_inline();
+        break;
+    case 0x185460:
+        value = pal_get_erxaddr_el1_inline();
+        break;
+    case 0x185420:
+        value = pal_get_erxctlr_el1_inline();
+        break;
+    case 0x185400:
+        value = pal_get_erxfr_el1_inline();
+        break;
+    case 0x185500:
+        value = pal_get_erxmisc0_el1_inline();
+        break;
+    case 0x185520:
+        value = pal_get_erxmisc1_el1_inline();
+        break;
+    case 0x185540:
+        value = pal_get_erxmisc2_el1_inline();
+        break;
+    case 0x185560:
+        value = pal_get_erxmisc3_el1_inline();
+        break;
+    case 0x1854c0:
+        value = pal_get_erxpfgcdn_el1_inline();
+        break;
+    case 0x1854a0:
+        value = pal_get_erxpfgctl_el1_inline();
+        break;
+    case 0x185480:
+        value = pal_get_erxpfgf_el1_inline();
+        break;
+    case 0x185440:
+        value = pal_get_erxstatus_el1_inline();
+        break;
+    case 0x185200:
+        value = pal_get_esr_el1_inline();
+        break;
+    case 0x1c5200:
+        value = pal_get_esr_el2_inline();
+        break;
+    case 0x1e5200:
+        value = pal_get_esr_el3_inline();
+        break;
+    case 0x186000:
+        value = pal_get_far_el1_inline();
+        break;
+    case 0x1c6000:
+        value = pal_get_far_el2_inline();
+        break;
+    case 0x1e6000:
+        value = pal_get_far_el3_inline();
+        break;
+    case 0x1b4400:
+        value = pal_get_fpcr_inline();
+        break;
+    case 0x1c5300:
+        value = pal_get_fpexc32_el2_inline();
+        break;
+    case 0x1b4420:
+        value = pal_get_fpsr_inline();
+        break;
+    case 0x1810c0:
+        value = pal_get_gcr_el1_inline();
+        break;
+    case 0x1c11e0:
+        value = pal_get_hacr_el2_inline();
+        break;
+    case 0x1c1100:
+        value = pal_get_hcr_el2_inline();
+        break;
+    case 0x1c6080:
+        value = pal_get_hpfar_el2_inline();
+        break;
+    case 0x1c1160:
+        value = pal_get_hstr_el2_inline();
+        break;
+    case 0x18c880:
+        value = pal_get_icc_ap0r0_el1_inline();
+        break;
+    case 0x18c8a0:
+        value = pal_get_icc_ap0r1_el1_inline();
+        break;
+    case 0x18c8c0:
+        value = pal_get_icc_ap0r2_el1_inline();
+        break;
+    case 0x18c8e0:
+        value = pal_get_icc_ap0r3_el1_inline();
+        break;
+    case 0x18c900:
+        value = pal_get_icc_ap1r0_el1_inline();
+        break;
+    case 0x18c920:
+        value = pal_get_icc_ap1r1_el1_inline();
+        break;
+    case 0x18c940:
+        value = pal_get_icc_ap1r2_el1_inline();
+        break;
+    case 0x18c960:
+        value = pal_get_icc_ap1r3_el1_inline();
+        break;
+    case 0x18c860:
+        value = pal_get_icc_bpr0_el1_inline();
+        break;
+    case 0x18cc60:
+        value = pal_get_icc_bpr1_el1_inline();
+        break;
+    case 0x18cc80:
+        value = pal_get_icc_ctlr_el1_inline();
+        break;
+    case 0x1ecc80:
+        value = pal_get_icc_ctlr_el3_inline();
+        break;
+    case 0x18c840:
+        value = pal_get_icc_hppir0_el1_inline();
+        break;
+    case 0x18cc40:
+        value = pal_get_icc_hppir1_el1_inline();
+        break;
+    case 0x18c800:
+        value = pal_get_icc_iar0_el1_inline();
+        break;
+    case 0x18cc00:
+        value = pal_get_icc_iar1_el1_inline();
+        break;
+    case 0x18ccc0:
+        value = pal_get_icc_igrpen0_el1_inline();
+        break;
+    case 0x18cce0:
+        value = pal_get_icc_igrpen1_el1_inline();
+        break;
+    case 0x1ecce0:
+        value = pal_get_icc_igrpen1_el3_inline();
+        break;
+    case 0x184600:
+        value = pal_get_icc_pmr_el1_inline();
+        break;
+    case 0x18cb60:
+        value = pal_get_icc_rpr_el1_inline();
+        break;
+    case 0x18cca0:
+        value = pal_get_icc_sre_el1_inline();
+        break;
+    case 0x1cc9a0:
+        value = pal_get_icc_sre_el2_inline();
+        break;
+    case 0x1ecca0:
+        value = pal_get_icc_sre_el3_inline();
+        break;
+    case 0x1cc800:
+        value = pal_get_ich_ap0r0_el2_inline();
+        break;
+    case 0x1cc820:
+        value = pal_get_ich_ap0r1_el2_inline();
+        break;
+    case 0x1cc840:
+        value = pal_get_ich_ap0r2_el2_inline();
+        break;
+    case 0x1cc860:
+        value = pal_get_ich_ap0r3_el2_inline();
+        break;
+    case 0x1cc900:
+        value = pal_get_ich_ap1r0_el2_inline();
+        break;
+    case 0x1cc920:
+        value = pal_get_ich_ap1r1_el2_inline();
+        break;
+    case 0x1cc940:
+        value = pal_get_ich_ap1r2_el2_inline();
+        break;
+    case 0x1cc960:
+        value = pal_get_ich_ap1r3_el2_inline();
+        break;
+    case 0x1ccb60:
+        value = pal_get_ich_eisr_el2_inline();
+        break;
+    case 0x1ccba0:
+        value = pal_get_ich_elrsr_el2_inline();
+        break;
+    case 0x1ccb00:
+        value = pal_get_ich_hcr_el2_inline();
+        break;
+    case 0x1ccc00:
+        value = pal_get_ich_lr0_el2_inline();
+        break;
+    case 0x1ccd40:
+        value = pal_get_ich_lr10_el2_inline();
+        break;
+    case 0x1ccd60:
+        value = pal_get_ich_lr11_el2_inline();
+        break;
+    case 0x1ccd80:
+        value = pal_get_ich_lr12_el2_inline();
+        break;
+    case 0x1ccda0:
+        value = pal_get_ich_lr13_el2_inline();
+        break;
+    case 0x1ccdc0:
+        value = pal_get_ich_lr14_el2_inline();
+        break;
+    case 0x1ccde0:
+        value = pal_get_ich_lr15_el2_inline();
+        break;
+    case 0x1ccc20:
+        value = pal_get_ich_lr1_el2_inline();
+        break;
+    case 0x1ccc40:
+        value = pal_get_ich_lr2_el2_inline();
+        break;
+    case 0x1ccc60:
+        value = pal_get_ich_lr3_el2_inline();
+        break;
+    case 0x1ccc80:
+        value = pal_get_ich_lr4_el2_inline();
+        break;
+    case 0x1ccca0:
+        value = pal_get_ich_lr5_el2_inline();
+        break;
+    case 0x1cccc0:
+        value = pal_get_ich_lr6_el2_inline();
+        break;
+    case 0x1ccce0:
+        value = pal_get_ich_lr7_el2_inline();
+        break;
+    case 0x1ccd00:
+        value = pal_get_ich_lr8_el2_inline();
+        break;
+    case 0x1ccd20:
+        value = pal_get_ich_lr9_el2_inline();
+        break;
+    case 0x1ccb40:
+        value = pal_get_ich_misr_el2_inline();
+        break;
+    case 0x1ccbe0:
+        value = pal_get_ich_vmcr_el2_inline();
+        break;
+    case 0x1ccb20:
+        value = pal_get_ich_vtr_el2_inline();
+        break;
+    case 0x180580:
+        value = pal_get_id_aa64afr0_el1_inline();
+        break;
+    case 0x1805a0:
+        value = pal_get_id_aa64afr1_el1_inline();
+        break;
+    case 0x180500:
+        value = pal_get_id_aa64dfr0_el1_inline();
+        break;
+    case 0x180520:
+        value = pal_get_id_aa64dfr1_el1_inline();
+        break;
+    case 0x180600:
+        value = pal_get_id_aa64isar0_el1_inline();
+        break;
+    case 0x180620:
+        value = pal_get_id_aa64isar1_el1_inline();
+        break;
+    case 0x180700:
+        value = pal_get_id_aa64mmfr0_el1_inline();
+        break;
+    case 0x180720:
+        value = pal_get_id_aa64mmfr1_el1_inline();
+        break;
+    case 0x180740:
+        value = pal_get_id_aa64mmfr2_el1_inline();
+        break;
+    case 0x180400:
+        value = pal_get_id_aa64pfr0_el1_inline();
+        break;
+    case 0x180420:
+        value = pal_get_id_aa64pfr1_el1_inline();
+        break;
+    case 0x180480:
+        value = pal_get_id_aa64zfr0_el1_inline();
+        break;
+    case 0x180160:
+        value = pal_get_id_afr0_el1_inline();
+        break;
+    case 0x180140:
+        value = pal_get_id_dfr0_el1_inline();
+        break;
+    case 0x180200:
+        value = pal_get_id_isar0_el1_inline();
+        break;
+    case 0x180220:
+        value = pal_get_id_isar1_el1_inline();
+        break;
+    case 0x180240:
+        value = pal_get_id_isar2_el1_inline();
+        break;
+    case 0x180260:
+        value = pal_get_id_isar3_el1_inline();
+        break;
+    case 0x180280:
+        value = pal_get_id_isar4_el1_inline();
+        break;
+    case 0x1802a0:
+        value = pal_get_id_isar5_el1_inline();
+        break;
+    case 0x1802e0:
+        value = pal_get_id_isar6_el1_inline();
+        break;
+    case 0x180180:
+        value = pal_get_id_mmfr0_el1_inline();
+        break;
+    case 0x1801a0:
+        value = pal_get_id_mmfr1_el1_inline();
+        break;
+    case 0x1801c0:
+        value = pal_get_id_mmfr2_el1_inline();
+        break;
+    case 0x1801e0:
+        value = pal_get_id_mmfr3_el1_inline();
+        break;
+    case 0x1802c0:
+        value = pal_get_id_mmfr4_el1_inline();
+        break;
+    case 0x180100:
+        value = pal_get_id_pfr0_el1_inline();
+        break;
+    case 0x180120:
+        value = pal_get_id_pfr1_el1_inline();
+        break;
+    case 0x180380:
+        value = pal_get_id_pfr2_el1_inline();
+        break;
+    case 0x1c5020:
+        value = pal_get_ifsr32_el2_inline();
+        break;
+    case 0x18c100:
+        value = pal_get_isr_el1_inline();
+        break;
+    case 0x18a460:
+        value = pal_get_lorc_el1_inline();
+        break;
+    case 0x18a420:
+        value = pal_get_lorea_el1_inline();
+        break;
+    case 0x18a4e0:
+        value = pal_get_lorid_el1_inline();
+        break;
+    case 0x18a440:
+        value = pal_get_lorn_el1_inline();
+        break;
+    case 0x18a400:
+        value = pal_get_lorsa_el1_inline();
+        break;
+    case 0x18a200:
+        value = pal_get_mair_el1_inline();
+        break;
+    case 0x1ca200:
+        value = pal_get_mair_el2_inline();
+        break;
+    case 0x1ea200:
+        value = pal_get_mair_el3_inline();
+        break;
+    case 0x100200:
+        value = pal_get_mdccint_el1_inline();
+        break;
+    case 0x130100:
+        value = pal_get_mdccsr_el0_inline();
+        break;
+    case 0x1c1120:
+        value = pal_get_mdcr_el2_inline();
+        break;
+    case 0x1e1320:
+        value = pal_get_mdcr_el3_inline();
+        break;
+    case 0x101000:
+        value = pal_get_mdrar_el1_inline();
+        break;
+    case 0x100240:
+        value = pal_get_mdscr_el1_inline();
+        break;
+    case 0x180000:
+        value = pal_get_midr_el1_inline();
+        break;
+    case 0x18a520:
+        value = pal_get_mpam0_el1_inline();
+        break;
+    case 0x18a500:
+        value = pal_get_mpam1_el1_inline();
+        break;
+    case 0x1ca500:
+        value = pal_get_mpam2_el2_inline();
+        break;
+    case 0x1ea500:
+        value = pal_get_mpam3_el3_inline();
+        break;
+    case 0x1ca400:
+        value = pal_get_mpamhcr_el2_inline();
+        break;
+    case 0x18a480:
+        value = pal_get_mpamidr_el1_inline();
+        break;
+    case 0x1ca600:
+        value = pal_get_mpamvpm0_el2_inline();
+        break;
+    case 0x1ca620:
+        value = pal_get_mpamvpm1_el2_inline();
+        break;
+    case 0x1ca640:
+        value = pal_get_mpamvpm2_el2_inline();
+        break;
+    case 0x1ca660:
+        value = pal_get_mpamvpm3_el2_inline();
+        break;
+    case 0x1ca680:
+        value = pal_get_mpamvpm4_el2_inline();
+        break;
+    case 0x1ca6a0:
+        value = pal_get_mpamvpm5_el2_inline();
+        break;
+    case 0x1ca6c0:
+        value = pal_get_mpamvpm6_el2_inline();
+        break;
+    case 0x1ca6e0:
+        value = pal_get_mpamvpm7_el2_inline();
+        break;
+    case 0x1ca420:
+        value = pal_get_mpamvpmv_el2_inline();
+        break;
+    case 0x1800a0:
+        value = pal_get_mpidr_el1_inline();
+        break;
+    case 0x180300:
+        value = pal_get_mvfr0_el1_inline();
+        break;
+    case 0x180320:
+        value = pal_get_mvfr1_el1_inline();
+        break;
+    case 0x180340:
+        value = pal_get_mvfr2_el1_inline();
+        break;
+    case 0x1b4200:
+        value = pal_get_nzcv_inline();
+        break;
+    case 0x101380:
+        value = pal_get_osdlr_el1_inline();
+        break;
+    case 0x100040:
+        value = pal_get_osdtrrx_el1_inline();
+        break;
+    case 0x100340:
+        value = pal_get_osdtrtx_el1_inline();
+        break;
+    case 0x100640:
+        value = pal_get_oseccr_el1_inline();
+        break;
+    case 0x101180:
+        value = pal_get_oslsr_el1_inline();
+        break;
+    case 0x184260:
+        value = pal_get_pan_inline();
+        break;
+    case 0x187400:
+        value = pal_get_par_el1_inline();
+        break;
+    case 0x189ae0:
+        value = pal_get_pmbidr_el1_inline();
+        break;
+    case 0x189a00:
+        value = pal_get_pmblimitr_el1_inline();
+        break;
+    case 0x189a20:
+        value = pal_get_pmbptr_el1_inline();
+        break;
+    case 0x189a60:
+        value = pal_get_pmbsr_el1_inline();
+        break;
+    case 0x1befe0:
+        value = pal_get_pmccfiltr_el0_inline();
+        break;
+    case 0x1b9d00:
+        value = pal_get_pmccntr_el0_inline();
+        break;
+    case 0x1b9cc0:
+        value = pal_get_pmceid0_el0_inline();
+        break;
+    case 0x1b9ce0:
+        value = pal_get_pmceid1_el0_inline();
+        break;
+    case 0x1b9c40:
+        value = pal_get_pmcntenclr_el0_inline();
+        break;
+    case 0x1b9c20:
+        value = pal_get_pmcntenset_el0_inline();
+        break;
+    case 0x1b9c00:
+        value = pal_get_pmcr_el0_inline();
+        break;
+    case 0x1be800:
+        value = pal_get_pmevcntr0_el0_inline();
+        break;
+    case 0x1be940:
+        value = pal_get_pmevcntr10_el0_inline();
+        break;
+    case 0x1be960:
+        value = pal_get_pmevcntr11_el0_inline();
+        break;
+    case 0x1be980:
+        value = pal_get_pmevcntr12_el0_inline();
+        break;
+    case 0x1be9a0:
+        value = pal_get_pmevcntr13_el0_inline();
+        break;
+    case 0x1be9c0:
+        value = pal_get_pmevcntr14_el0_inline();
+        break;
+    case 0x1be9e0:
+        value = pal_get_pmevcntr15_el0_inline();
+        break;
+    case 0x1bea00:
+        value = pal_get_pmevcntr16_el0_inline();
+        break;
+    case 0x1bea20:
+        value = pal_get_pmevcntr17_el0_inline();
+        break;
+    case 0x1bea40:
+        value = pal_get_pmevcntr18_el0_inline();
+        break;
+    case 0x1bea60:
+        value = pal_get_pmevcntr19_el0_inline();
+        break;
+    case 0x1be820:
+        value = pal_get_pmevcntr1_el0_inline();
+        break;
+    case 0x1bea80:
+        value = pal_get_pmevcntr20_el0_inline();
+        break;
+    case 0x1beaa0:
+        value = pal_get_pmevcntr21_el0_inline();
+        break;
+    case 0x1beac0:
+        value = pal_get_pmevcntr22_el0_inline();
+        break;
+    case 0x1beae0:
+        value = pal_get_pmevcntr23_el0_inline();
+        break;
+    case 0x1beb00:
+        value = pal_get_pmevcntr24_el0_inline();
+        break;
+    case 0x1beb20:
+        value = pal_get_pmevcntr25_el0_inline();
+        break;
+    case 0x1beb40:
+        value = pal_get_pmevcntr26_el0_inline();
+        break;
+    case 0x1beb60:
+        value = pal_get_pmevcntr27_el0_inline();
+        break;
+    case 0x1beb80:
+        value = pal_get_pmevcntr28_el0_inline();
+        break;
+    case 0x1beba0:
+        value = pal_get_pmevcntr29_el0_inline();
+        break;
+    case 0x1be840:
+        value = pal_get_pmevcntr2_el0_inline();
+        break;
+    case 0x1bebc0:
+        value = pal_get_pmevcntr30_el0_inline();
+        break;
+    case 0x1be860:
+        value = pal_get_pmevcntr3_el0_inline();
+        break;
+    case 0x1be880:
+        value = pal_get_pmevcntr4_el0_inline();
+        break;
+    case 0x1be8a0:
+        value = pal_get_pmevcntr5_el0_inline();
+        break;
+    case 0x1be8c0:
+        value = pal_get_pmevcntr6_el0_inline();
+        break;
+    case 0x1be8e0:
+        value = pal_get_pmevcntr7_el0_inline();
+        break;
+    case 0x1be900:
+        value = pal_get_pmevcntr8_el0_inline();
+        break;
+    case 0x1be920:
+        value = pal_get_pmevcntr9_el0_inline();
+        break;
+    case 0x1bec00:
+        value = pal_get_pmevtyper0_el0_inline();
+        break;
+    case 0x1bed40:
+        value = pal_get_pmevtyper10_el0_inline();
+        break;
+    case 0x1bed60:
+        value = pal_get_pmevtyper11_el0_inline();
+        break;
+    case 0x1bed80:
+        value = pal_get_pmevtyper12_el0_inline();
+        break;
+    case 0x1beda0:
+        value = pal_get_pmevtyper13_el0_inline();
+        break;
+    case 0x1bedc0:
+        value = pal_get_pmevtyper14_el0_inline();
+        break;
+    case 0x1bede0:
+        value = pal_get_pmevtyper15_el0_inline();
+        break;
+    case 0x1bee00:
+        value = pal_get_pmevtyper16_el0_inline();
+        break;
+    case 0x1bee20:
+        value = pal_get_pmevtyper17_el0_inline();
+        break;
+    case 0x1bee40:
+        value = pal_get_pmevtyper18_el0_inline();
+        break;
+    case 0x1bee60:
+        value = pal_get_pmevtyper19_el0_inline();
+        break;
+    case 0x1bec20:
+        value = pal_get_pmevtyper1_el0_inline();
+        break;
+    case 0x1bee80:
+        value = pal_get_pmevtyper20_el0_inline();
+        break;
+    case 0x1beea0:
+        value = pal_get_pmevtyper21_el0_inline();
+        break;
+    case 0x1beec0:
+        value = pal_get_pmevtyper22_el0_inline();
+        break;
+    case 0x1beee0:
+        value = pal_get_pmevtyper23_el0_inline();
+        break;
+    case 0x1bef00:
+        value = pal_get_pmevtyper24_el0_inline();
+        break;
+    case 0x1bef20:
+        value = pal_get_pmevtyper25_el0_inline();
+        break;
+    case 0x1bef40:
+        value = pal_get_pmevtyper26_el0_inline();
+        break;
+    case 0x1bef60:
+        value = pal_get_pmevtyper27_el0_inline();
+        break;
+    case 0x1bef80:
+        value = pal_get_pmevtyper28_el0_inline();
+        break;
+    case 0x1befa0:
+        value = pal_get_pmevtyper29_el0_inline();
+        break;
+    case 0x1bec40:
+        value = pal_get_pmevtyper2_el0_inline();
+        break;
+    case 0x1befc0:
+        value = pal_get_pmevtyper30_el0_inline();
+        break;
+    case 0x1bec60:
+        value = pal_get_pmevtyper3_el0_inline();
+        break;
+    case 0x1bec80:
+        value = pal_get_pmevtyper4_el0_inline();
+        break;
+    case 0x1beca0:
+        value = pal_get_pmevtyper5_el0_inline();
+        break;
+    case 0x1becc0:
+        value = pal_get_pmevtyper6_el0_inline();
+        break;
+    case 0x1bece0:
+        value = pal_get_pmevtyper7_el0_inline();
+        break;
+    case 0x1bed00:
+        value = pal_get_pmevtyper8_el0_inline();
+        break;
+    case 0x1bed20:
+        value = pal_get_pmevtyper9_el0_inline();
+        break;
+    case 0x189e40:
+        value = pal_get_pmintenclr_el1_inline();
+        break;
+    case 0x189e20:
+        value = pal_get_pmintenset_el1_inline();
+        break;
+    case 0x189ec0:
+        value = pal_get_pmmir_el1_inline();
+        break;
+    case 0x1b9c60:
+        value = pal_get_pmovsclr_el0_inline();
+        break;
+    case 0x1b9e60:
+        value = pal_get_pmovsset_el0_inline();
+        break;
+    case 0x189900:
+        value = pal_get_pmscr_el1_inline();
+        break;
+    case 0x1c9900:
+        value = pal_get_pmscr_el2_inline();
+        break;
+    case 0x1b9ca0:
+        value = pal_get_pmselr_el0_inline();
+        break;
+    case 0x1899a0:
+        value = pal_get_pmsevfr_el1_inline();
+        break;
+    case 0x189980:
+        value = pal_get_pmsfcr_el1_inline();
+        break;
+    case 0x189940:
+        value = pal_get_pmsicr_el1_inline();
+        break;
+    case 0x1899e0:
+        value = pal_get_pmsidr_el1_inline();
+        break;
+    case 0x189960:
+        value = pal_get_pmsirr_el1_inline();
+        break;
+    case 0x1899c0:
+        value = pal_get_pmslatfr_el1_inline();
+        break;
+    case 0x1b9e00:
+        value = pal_get_pmuserenr_el0_inline();
+        break;
+    case 0x1b9d40:
+        value = pal_get_pmxevcntr_el0_inline();
+        break;
+    case 0x1b9d20:
+        value = pal_get_pmxevtyper_el0_inline();
+        break;
+    case 0x1800c0:
+        value = pal_get_revidr_el1_inline();
+        break;
+    case 0x1810a0:
+        value = pal_get_rgsr_el1_inline();
+        break;
+    case 0x18c040:
+        value = pal_get_rmr_el1_inline();
+        break;
+    case 0x1cc040:
+        value = pal_get_rmr_el2_inline();
+        break;
+    case 0x1ec040:
+        value = pal_get_rmr_el3_inline();
+        break;
+    case 0x1b2400:
+        value = pal_get_rndr_inline();
+        break;
+    case 0x1b2420:
+        value = pal_get_rndrrs_inline();
+        break;
+    case 0x18c020:
+        value = pal_get_rvbar_el1_inline();
+        break;
+    case 0x1cc020:
+        value = pal_get_rvbar_el2_inline();
+        break;
+    case 0x1ec020:
+        value = pal_get_rvbar_el3_inline();
+        break;
+    case 0x1e1100:
+        value = pal_get_scr_el3_inline();
+        break;
+    case 0x181000:
+        value = pal_get_sctlr_el1_inline();
+        break;
+    case 0x1c1000:
+        value = pal_get_sctlr_el2_inline();
+        break;
+    case 0x1e1000:
+        value = pal_get_sctlr_el3_inline();
+        break;
+    case 0x1bd0e0:
+        value = pal_get_scxtnum_el0_inline();
+        break;
+    case 0x18d0e0:
+        value = pal_get_scxtnum_el1_inline();
+        break;
+    case 0x1cd0e0:
+        value = pal_get_scxtnum_el2_inline();
+        break;
+    case 0x1ed0e0:
+        value = pal_get_scxtnum_el3_inline();
+        break;
+    case 0x1c1320:
+        value = pal_get_sder32_el2_inline();
+        break;
+    case 0x1e1120:
+        value = pal_get_sder32_el3_inline();
+        break;
+    case 0x184100:
+        value = pal_get_sp_el0_inline();
+        break;
+    case 0x1c4100:
+        value = pal_get_sp_el1_inline();
+        break;
+    case 0x1e4100:
+        value = pal_get_sp_el2_inline();
+        break;
+    case 0x184200:
+        value = pal_get_spsel_inline();
+        break;
+    case 0x1c4320:
+        value = pal_get_spsr_abt_inline();
+        break;
+    case 0x184000:
+        value = pal_get_spsr_el1_inline();
+        break;
+    case 0x1c4000:
+        value = pal_get_spsr_el2_inline();
+        break;
+    case 0x1e4000:
+        value = pal_get_spsr_el3_inline();
+        break;
+    case 0x1c4360:
+        value = pal_get_spsr_fiq_inline();
+        break;
+    case 0x1c4300:
+        value = pal_get_spsr_irq_inline();
+        break;
+    case 0x1c4340:
+        value = pal_get_spsr_und_inline();
+        break;
+    case 0x1b42c0:
+        value = pal_get_ssbs_inline();
+        break;
+    case 0x1b42e0:
+        value = pal_get_tco_inline();
+        break;
+    case 0x182040:
+        value = pal_get_tcr_el1_inline();
+        break;
+    case 0x1c2040:
+        value = pal_get_tcr_el2_inline();
+        break;
+    case 0x1e2040:
+        value = pal_get_tcr_el3_inline();
+        break;
+    case 0x186500:
+        value = pal_get_tfsr_el1_inline();
+        break;
+    case 0x1c6500:
+        value = pal_get_tfsr_el2_inline();
+        break;
+    case 0x1e6500:
+        value = pal_get_tfsr_el3_inline();
+        break;
+    case 0x186620:
+        value = pal_get_tfsre0_el1_inline();
+        break;
+    case 0x1bd040:
+        value = pal_get_tpidr_el0_inline();
+        break;
+    case 0x18d080:
+        value = pal_get_tpidr_el1_inline();
+        break;
+    case 0x1cd040:
+        value = pal_get_tpidr_el2_inline();
+        break;
+    case 0x1ed040:
+        value = pal_get_tpidr_el3_inline();
+        break;
+    case 0x1bd060:
+        value = pal_get_tpidrro_el0_inline();
+        break;
+    case 0x181220:
+        value = pal_get_trfcr_el1_inline();
+        break;
+    case 0x1c1220:
+        value = pal_get_trfcr_el2_inline();
+        break;
+    case 0x182000:
+        value = pal_get_ttbr0_el1_inline();
+        break;
+    case 0x1c2000:
+        value = pal_get_ttbr0_el2_inline();
+        break;
+    case 0x1e2000:
+        value = pal_get_ttbr0_el3_inline();
+        break;
+    case 0x182020:
+        value = pal_get_ttbr1_el1_inline();
+        break;
+    case 0x1c2020:
+        value = pal_get_ttbr1_el2_inline();
+        break;
+    case 0x184280:
+        value = pal_get_uao_inline();
+        break;
+    case 0x18c000:
+        value = pal_get_vbar_el1_inline();
+        break;
+    case 0x1cc000:
+        value = pal_get_vbar_el2_inline();
+        break;
+    case 0x1ec000:
+        value = pal_get_vbar_el3_inline();
+        break;
+    case 0x1cc120:
+        value = pal_get_vdisr_el2_inline();
+        break;
+    case 0x1c00a0:
+        value = pal_get_vmpidr_el2_inline();
+        break;
+    case 0x1c2200:
+        value = pal_get_vncr_el2_inline();
+        break;
+    case 0x1c0000:
+        value = pal_get_vpidr_el2_inline();
+        break;
+    case 0x1c5260:
+        value = pal_get_vsesr_el2_inline();
+        break;
+    case 0x1c2640:
+        value = pal_get_vstcr_el2_inline();
+        break;
+    case 0x1c2600:
+        value = pal_get_vsttbr_el2_inline();
+        break;
+    case 0x1c2140:
+        value = pal_get_vtcr_el2_inline();
+        break;
+    case 0x1c2100:
+        value = pal_get_vttbr_el2_inline();
+        break;
+    case 0x181200:
+        value = pal_get_zcr_el1_inline();
+        break;
+    case 0x1c1200:
+        value = pal_get_zcr_el2_inline();
+        break;
+    case 0x1e1200:
+        value = pal_get_zcr_el3_inline();
+        break;
+    default:
+        printk(KERN_INFO "Defualt case!");
+        return -EINVAL;
+    }
+    
     kern_ops.out.value = value;
     if (copy_to_user(user_ops, &kern_ops, sizeof(struct sysl_operands)))
         return -1;

--- a/example/c++11/CMakeLists.txt
+++ b/example/c++11/CMakeLists.txt
@@ -1,3 +1,7 @@
 if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL x86_64)
     add_subdirectory(intel)
 endif()
+
+if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL aarch64)
+    add_subdirectory(armv8a)
+endif()

--- a/example/c++11/armv8a/CMakeLists.txt
+++ b/example/c++11/armv8a/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(c++_example_dependencies INTERFACE)
+
+if(PAL_ARMV8A_AARCH64_AAPCS64_GNUINLINE)
+    target_link_libraries(c++_example_dependencies INTERFACE pal_armv8a_aarch64_aapcs64_gnuinline c++11_armv8a_aarch64_aapcs64_gnuinline)
+elseif(PAL_ARMV8A_AARCH64_LINUX_IOCTL)
+    target_link_libraries(c++_example_dependencies INTERFACE pal_armv8a_aarch64_linux_ioctl c++11_armv8a_aarch64_linux_ioctl)
+else()
+    message(FATAL_ERROR "Must enable at least one ARMv8a-based pal implementation to build ARMv8a example projects")
+endif()
+
+add_executable(c++_basic_usage basic_usage.cpp)
+target_link_libraries(c++_basic_usage c++_example_dependencies)

--- a/example/c++11/armv8a/basic_usage.cpp
+++ b/example/c++11/armv8a/basic_usage.cpp
@@ -1,0 +1,9 @@
+// TODO: Import generated PAL headers here
+
+#include <iostream>
+
+int main()
+{
+    std::cout << "TODO: Implement an example that usees PAL to read SCTLR_EL1" << std::endl;
+    std::cout << "NOTE: Don't forget to load the devpal driver before running the example!" << std::endl;
+}

--- a/example/c/CMakeLists.txt
+++ b/example/c/CMakeLists.txt
@@ -1,3 +1,7 @@
 if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL x86_64)
     add_subdirectory(intel)
 endif()
+
+if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL aarch64)
+    add_subdirectory(armv8a)
+endif()

--- a/example/c/armv8a/CMakeLists.txt
+++ b/example/c/armv8a/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(c_example_dependencies INTERFACE)
+
+if(PAL_ARMV8A_AARCH64_AAPCS64_GNUINLINE)
+    target_link_libraries(c_example_dependencies INTERFACE pal_armv8a_aarch64_aapcs64_gnuinline c_armv8a_aarch64_aapcs64_gnuinline)
+elseif(PAL_ARMV8A_AARCH64_LINUX_IOCTL)
+    target_link_libraries(c_example_dependencies INTERFACE pal_armv8a_aarch64_linux_ioctl c_armv8a_aarch64_linux_ioctl)
+else()
+    message(FATAL_ERROR "Must enable at least one ARMv8a-based pal implementation to build ARMv8a example projects")
+endif()
+
+add_executable(c_basic_usage basic_usage.c)
+target_link_libraries(c_basic_usage c_example_dependencies)

--- a/example/c/armv8a/basic_usage.c
+++ b/example/c/armv8a/basic_usage.c
@@ -9,6 +9,17 @@ int main(void)
 
     uint64_t val =  pal_get_sctlr_el1();
     pal_print_sctlr_el1_from_value(printf, val);
-    printf("SCTLR_EL1 decimal:: %ld\n", val);
-    printf("SCTLR_EL1 hex:: %lx\n", val);
+    printf("SCTLR_EL1 hex: %lx\n", val);
+
+    // Change a specific bit in sctlr_el1
+    /*
+    uint64_t tmp = 0x8;
+    val ^= tmp;
+    printf("After xor: %lx\n", val);
+    pal_set_sctlr_el1(val);
+
+    val = pal_get_sctlr_el1();
+    printf("SCTLR_EL1 hex: %lx\n", val);
+    pal_print_sctlr_el1_from_value(printf, val);
+    */
 }

--- a/example/c/armv8a/basic_usage.c
+++ b/example/c/armv8a/basic_usage.c
@@ -10,6 +10,9 @@
 #include <pal/aarch64/dbgauthstatus_el1.h>
 #include <pal/aarch64/dbgbcr0_el1.h>
 
+#include "pal/a64/smc.h"
+#include "pal/a64/hvc.h"
+
 int test_func(void) {
     printf("Hello World\n");
     return 0;
@@ -71,4 +74,28 @@ int main(void)
     val = pal_get_elr_el1();
     printf("elr hex: %lx\n", val);
     pal_print_elr_el1_from_value(printf, val);
+
+    printf("=====================================\n");
+    struct hvc_operands args = {0};
+    args.in.W0 = 0x84000000;
+    //args.in.X1 = 0xdeadbeef;
+    // args.in.X2 = 0xdeadbeef;
+    // args.in.X3 = 0xdeadbeef;
+    args = pal_execute_hvc(&args);
+
+    printf("Here X0: %lx\n", args.out.X0);
+    printf("Here X1: %lx\n", args.out.X1);
+    printf("Here X2: %lx\n", args.out.X2);
+    printf("Here X3: %lx\n", args.out.X3);
+    printf("Here X4: %lx\n", args.out.X4);
+    printf("Here X5: %lx\n", args.out.X5);
+    printf("Here X6: %lx\n", args.out.X6);
+    printf("Here X7: %lx\n", args.out.X7);
+    printf("Here X8: %lx\n", args.out.X8);
+    printf("Here X9: %lx\n", args.out.X9);
+    printf("Here X10: %lx\n", args.out.X10);
+    printf("Here X11: %lx\n", args.out.X11);
+    printf("Here X12: %lx\n", args.out.X12);
+    printf("Here X13: %lx\n", args.out.X13);
+    printf("Here X14: %lx\n", args.out.X14);
 }

--- a/example/c/armv8a/basic_usage.c
+++ b/example/c/armv8a/basic_usage.c
@@ -2,24 +2,73 @@
 
 #include <stdio.h>
 #include <pal/aarch64/sctlr_el1.h>
+#include <pal/aarch64/esr_el1.h>
+#include <pal/aarch64/elr_el1.h>
+#include <pal/aarch64/spsr_el1.h>
+#include <pal/aarch64/ttbr0_el1.h>
+#include <pal/aarch64/vbar_el1.h>
+#include <pal/aarch64/dbgauthstatus_el1.h>
+#include <pal/aarch64/dbgbcr0_el1.h>
+
+int test_func(void) {
+    printf("Hello World\n");
+    return 0;
+}
 
 int main(void)
 {
     printf("NOTE: Don't forget to load the devpal driver before running the example!\n");
 
-    uint64_t val =  pal_get_sctlr_el1();
+    uint64_t val = pal_get_esr_el1();
+    pal_print_esr_el1_from_value(printf, val);
+    printf("esr_el1 hex: %lx\n", val);
+
+    val =  pal_get_sctlr_el1();
     pal_print_sctlr_el1_from_value(printf, val);
     printf("SCTLR_EL1 hex: %lx\n", val);
 
-    // Change a specific bit in sctlr_el1
-    /*
-    uint64_t tmp = 0x8;
-    val ^= tmp;
-    printf("After xor: %lx\n", val);
-    pal_set_sctlr_el1(val);
+    val = pal_get_elr_el1();
+    pal_print_elr_el1_from_value(printf, val);
 
-    val = pal_get_sctlr_el1();
-    printf("SCTLR_EL1 hex: %lx\n", val);
-    pal_print_sctlr_el1_from_value(printf, val);
-    */
+    val = pal_get_spsr_el1();
+    pal_print_spsr_el1_fieldset_2_from_value(printf, val);
+
+    val = pal_get_ttbr0_el1();
+    pal_print_ttbr0_el1_from_value(printf, val);
+
+    val = pal_get_vbar_el1();
+    pal_print_vbar_el1_from_value(printf, val);
+
+    val = pal_get_dbgauthstatus_el1();
+    pal_print_dbgauthstatus_el1_from_value(printf, val);
+
+    val = pal_get_dbgbcr0_el1();
+    pal_print_dbgbcr0_el1_from_value(printf, val);
+
+    // Set functions from here on DANGER ZONE. Real danger of crushing the system
+
+    // pal_set_elr_el1(test_func);
+    
+
+    // Change contents of dbgbcr0_el1 register
+    val = pal_get_dbgbcr0_el1();
+    pal_print_dbgbcr0_el1_from_value(printf, val);
+
+    uint64_t tmp = 0x6;
+    //printf("After xor: %lx\n", val);
+    pal_set_dbgbcr0_el1(tmp);
+
+    val = pal_get_dbgbcr0_el1();
+    printf("dbgbcr0_el1 hex: %lx\n", val);
+    pal_print_dbgbcr0_el1_from_value(printf, val);
+
+    val = pal_get_elr_el1();
+    pal_print_elr_el1_from_value(printf, val);
+
+    printf("Here func addr: %p\n", test_func);
+    pal_set_elr_el1((uint64_t)test_func);
+
+    val = pal_get_elr_el1();
+    printf("elr hex: %lx\n", val);
+    pal_print_elr_el1_from_value(printf, val);
 }

--- a/example/c/armv8a/basic_usage.c
+++ b/example/c/armv8a/basic_usage.c
@@ -1,0 +1,9 @@
+// TODO: Import generated PAL headers here
+
+#include <stdio.h>
+
+int main(void)
+{
+    printf("TODO: Implement an example that usees PAL to read SCTLR_EL1\n");
+    printf("NOTE: Don't forget to load the devpal driver before running the example!\n");
+}

--- a/example/c/armv8a/basic_usage.c
+++ b/example/c/armv8a/basic_usage.c
@@ -1,9 +1,14 @@
 // TODO: Import generated PAL headers here
 
 #include <stdio.h>
+#include <pal/aarch64/sctlr_el1.h>
 
 int main(void)
 {
-    printf("TODO: Implement an example that usees PAL to read SCTLR_EL1\n");
     printf("NOTE: Don't forget to load the devpal driver before running the example!\n");
+
+    uint64_t val =  pal_get_sctlr_el1();
+    pal_print_sctlr_el1_from_value(printf, val);
+    printf("SCTLR_EL1 decimal:: %ld\n", val);
+    printf("SCTLR_EL1 hex:: %lx\n", val);
 }

--- a/example/c/armv8a/basic_usage.c
+++ b/example/c/armv8a/basic_usage.c
@@ -6,10 +6,16 @@
 #include <pal/aarch64/elr_el1.h>
 #include <pal/aarch64/spsr_el1.h>
 #include <pal/aarch64/ttbr0_el1.h>
+#include <pal/aarch64/ttbr1_el1.h>
+#include <pal/aarch64/vttbr_el2.h>
 #include <pal/aarch64/vbar_el1.h>
 #include <pal/aarch64/dbgauthstatus_el1.h>
 #include <pal/aarch64/dbgbcr0_el1.h>
+#include <pal/aarch64/par_el1.h>
+#include <pal/aarch64/pmmir_el1.h>
 
+#include "pal/a64/read_mem.h"
+#include "pal/a64/write_mem.h"
 #include "pal/a64/smc.h"
 #include "pal/a64/hvc.h"
 
@@ -22,31 +28,50 @@ int main(void)
 {
     printf("NOTE: Don't forget to load the devpal driver before running the example!\n");
 
-    uint64_t val = pal_get_esr_el1();
-    pal_print_esr_el1_from_value(printf, val);
-    printf("esr_el1 hex: %lx\n", val);
+    uint64_t val = 0;
+    uintptr_t tmp = 0;
 
-    val =  pal_get_sctlr_el1();
-    pal_print_sctlr_el1_from_value(printf, val);
-    printf("SCTLR_EL1 hex: %lx\n", val);
+    // val = pal_get_esr_el1();
+    // pal_print_esr_el1_from_value(printf, val);
 
-    val = pal_get_elr_el1();
-    pal_print_elr_el1_from_value(printf, val);
+    // val =  pal_get_sctlr_el1();
+    // pal_print_sctlr_el1_from_value(printf, val);
 
-    val = pal_get_spsr_el1();
-    pal_print_spsr_el1_fieldset_2_from_value(printf, val);
+    // val = pal_get_elr_el1();
+    // pal_print_elr_el1_from_value(printf, val);
+
+    // val = pal_get_spsr_el1();
+    // pal_print_spsr_el1_fieldset_2_from_value(printf, val);
 
     val = pal_get_ttbr0_el1();
     pal_print_ttbr0_el1_from_value(printf, val);
 
-    val = pal_get_vbar_el1();
-    pal_print_vbar_el1_from_value(printf, val);
+    val = pal_get_ttbr1_el1();
+    pal_print_ttbr1_el1_from_value(printf, val);
+    tmp = pal_get_ttbr1_el1_baddr();
+    printf("OOO: %p\n", (void *)tmp);
 
-    val = pal_get_dbgauthstatus_el1();
-    pal_print_dbgauthstatus_el1_from_value(printf, val);
+    val = pal_get_par_el1();
+    pal_print_par_el1_fieldset_1_sh_from_value(printf, val);
+    pal_print_par_el1_fieldset_2_s_from_value(printf, val);
 
-    val = pal_get_dbgbcr0_el1();
-    pal_print_dbgbcr0_el1_from_value(printf, val);
+    val = pal_get_pmmir_el1();
+    pal_print_pmmir_el1_from_value(printf, val);
+
+    // val = pal_get_vttbr_el2();
+    // pal_print_vttbr_el2_from_value(printf, val);
+    // //tmp = pal_get_ttbr1_el1_baddr();
+    // //printf("OOO: %p\n", (void *)tmp);
+    // printf("OOO: %lx\n", val);
+
+    // val = pal_get_vbar_el1();
+    // pal_print_vbar_el1_from_value(printf, val);
+
+    // val = pal_get_dbgauthstatus_el1();
+    // pal_print_dbgauthstatus_el1_from_value(printf, val);
+
+    // val = pal_get_dbgbcr0_el1();
+    // pal_print_dbgbcr0_el1_from_value(printf, val);
 
     // Set functions from here on DANGER ZONE. Real danger of crushing the system
 
@@ -54,33 +79,33 @@ int main(void)
     
 
     // Change contents of dbgbcr0_el1 register
-    val = pal_get_dbgbcr0_el1();
-    pal_print_dbgbcr0_el1_from_value(printf, val);
+    // val = pal_get_dbgbcr0_el1();
+    // pal_print_dbgbcr0_el1_from_value(printf, val);
 
-    uint64_t tmp = 0x6;
+    //uint64_t tmp = 0x6;
     //printf("After xor: %lx\n", val);
-    pal_set_dbgbcr0_el1(tmp);
+    //pal_set_dbgbcr0_el1(tmp);
 
-    val = pal_get_dbgbcr0_el1();
-    printf("dbgbcr0_el1 hex: %lx\n", val);
-    pal_print_dbgbcr0_el1_from_value(printf, val);
+    // val = pal_get_dbgbcr0_el1();
+    // printf("dbgbcr0_el1 hex: %lx\n", val);
+    // pal_print_dbgbcr0_el1_from_value(printf, val);
 
-    val = pal_get_elr_el1();
-    pal_print_elr_el1_from_value(printf, val);
+    // val = pal_get_elr_el1();
+    // pal_print_elr_el1_from_value(printf, val);
 
-    printf("Here func addr: %p\n", test_func);
-    pal_set_elr_el1((uint64_t)test_func);
+    // printf("Here func addr: %p\n", test_func);
+    // pal_set_elr_el1((uint64_t)test_func);
 
-    val = pal_get_elr_el1();
-    printf("elr hex: %lx\n", val);
-    pal_print_elr_el1_from_value(printf, val);
+    // val = pal_get_elr_el1();
+    // printf("elr hex: %lx\n", val);
+    // pal_print_elr_el1_from_value(printf, val);
 
     printf("=====================================\n");
     struct hvc_operands args = {0};
-    args.in.W0 = 0x84000000;
-    //args.in.X1 = 0xdeadbeef;
-    // args.in.X2 = 0xdeadbeef;
-    // args.in.X3 = 0xdeadbeef;
+    args.in.W0 = 0x84000132;
+    args.in.X1 = 0xdeadbeef;
+    args.in.X2 = 0x20;
+    args.in.X3 = 0x4;
     args = pal_execute_hvc(&args);
 
     printf("Here X0: %lx\n", args.out.X0);
@@ -98,4 +123,9 @@ int main(void)
     printf("Here X12: %lx\n", args.out.X12);
     printf("Here X13: %lx\n", args.out.X13);
     printf("Here X14: %lx\n", args.out.X14);
+
+    uintptr_t pp = 0x14fc50b7;
+    printf("Address example (userspace) program is trying to read: %p\n", (void *) pp);
+    val = pal_execute_read_mem64(pp);
+    printf("Here is the value: %lx\n", val);
 }

--- a/example/c/armv8a/pal/a64/hvc.h
+++ b/example/c/armv8a/pal/a64/hvc.h
@@ -1,0 +1,46 @@
+// ----------------------------------------------------------------------------
+struct hvc_inputs
+{
+    uint64_t W0;
+    uint64_t X1;
+    uint64_t X2;
+    uint64_t X3;
+    uint64_t X4;
+    uint64_t X5;
+    uint64_t X6;
+    uint64_t X7;
+    uint64_t X8;
+    uint64_t X9;
+    uint64_t X10;
+    uint64_t X11;
+    uint64_t X12;
+    uint64_t X13;
+    uint64_t X14;
+};
+
+struct hvc_outputs
+{
+    uint64_t X0;
+    uint64_t X1;
+    uint64_t X2;
+    uint64_t X3;
+    uint64_t X4;
+    uint64_t X5;
+    uint64_t X6;
+    uint64_t X7;
+    uint64_t X8;
+    uint64_t X9;
+    uint64_t X10;
+    uint64_t X11;
+    uint64_t X12;
+    uint64_t X13;
+    uint64_t X14;
+};
+
+struct hvc_operands
+{
+    struct hvc_inputs in;
+    struct hvc_outputs out;
+};
+
+struct hvc_operands pal_execute_hvc(struct hvc_operands *user_ops);

--- a/example/c/armv8a/pal/a64/read_mem.h
+++ b/example/c/armv8a/pal/a64/read_mem.h
@@ -1,0 +1,4 @@
+uint64_t pal_execute_read_mem64(uintptr_t address);
+uint32_t pal_execute_read_mem32(uintptr_t address);
+uint16_t pal_execute_read_mem16(uintptr_t address);
+uint8_t pal_execute_read_mem8(uintptr_t address);

--- a/example/c/armv8a/pal/a64/smc.h
+++ b/example/c/armv8a/pal/a64/smc.h
@@ -1,0 +1,46 @@
+// ----------------------------------------------------------------------------
+struct smc_inputs
+{
+    uint64_t W0;
+    uint64_t X1;
+    uint64_t X2;
+    uint64_t X3;
+    uint64_t X4;
+    uint64_t X5;
+    uint64_t X6;
+    uint64_t X7;
+    uint64_t X8;
+    uint64_t X9;
+    uint64_t X10;
+    uint64_t X11;
+    uint64_t X12;
+    uint64_t X13;
+    uint64_t X14;
+};
+
+struct smc_outputs
+{
+    uint64_t X0;
+    uint64_t X1;
+    uint64_t X2;
+    uint64_t X3;
+    uint64_t X4;
+    uint64_t X5;
+    uint64_t X6;
+    uint64_t X7;
+    uint64_t X8;
+    uint64_t X9;
+    uint64_t X10;
+    uint64_t X11;
+    uint64_t X12;
+    uint64_t X13;
+    uint64_t X14;
+};
+
+struct smc_operands
+{
+    struct smc_inputs in;
+    struct smc_outputs out;
+};
+
+struct smc_operands pal_execute_smc(struct smc_operands *user_ops);

--- a/example/c/armv8a/pal/a64/write_mem.h
+++ b/example/c/armv8a/pal/a64/write_mem.h
@@ -1,0 +1,4 @@
+uint64_t pal_execute_write_mem64(uintptr_t address);
+uint32_t pal_execute_write_mem32(uintptr_t address);
+uint16_t pal_execute_write_mem16(uintptr_t address);
+uint8_t pal_execute_write_mem8(uintptr_t address);

--- a/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/hvc_inline.h
+++ b/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/hvc_inline.h
@@ -1,0 +1,90 @@
+#include "devpal_abi_armv8a_aarch64.h"
+
+inline struct hvc_operands pal_execute_hvc_inline(struct hvc_operands * kern_ops)
+{
+    // Note teh strange X0 W0 case here per ARM manual
+    uint64_t X0 = (*kern_ops).in.W0;
+    uint64_t X1 = (*kern_ops).in.X1;
+    uint64_t X2 = (*kern_ops).in.X2;
+    uint64_t X3 = (*kern_ops).in.X3;
+    uint64_t X4 = (*kern_ops).in.X4;
+    uint64_t X5 = (*kern_ops).in.X5;
+    uint64_t X6 = (*kern_ops).in.X6;
+    uint64_t X7 = (*kern_ops).in.X7;
+    uint64_t X8 = (*kern_ops).in.X8;
+    uint64_t X9 = (*kern_ops).in.X9;
+    uint64_t X10 = (*kern_ops).in.X10;
+    uint64_t X11 = (*kern_ops).in.X11;
+    uint64_t X12 = (*kern_ops).in.X12;
+    uint64_t X13 = (*kern_ops).in.X13;
+    uint64_t X14 = (*kern_ops).in.X14;
+
+    __asm__ volatile(
+        "ldr w0, %0\n"
+        "ldr x1, %1\n"
+        "ldr x2, %2\n"
+        "ldr x3, %3\n"
+        "ldr x4, %4\n"
+        "ldr x5, %5\n"
+        "ldr x6, %6\n"
+        "ldr x7, %7\n"
+        "ldr x8, %8\n"
+        "ldr x9, %9\n"
+        "ldr x10, %10\n"
+        "ldr x11, %11\n"
+        "ldr x12, %12\n"
+        "ldr x13, %13\n"
+        "ldr x14, %14\n"
+        "hvc #0\n"
+        "str x0, %0\n"
+        "str x1, %1\n"
+        "str x2, %2\n"
+        "str x3, %3\n"
+        "str x4, %4\n"
+        "str x5, %5\n"
+        "str x6, %6\n"
+        "str x7, %7\n"
+        "str x8, %8\n"
+        "str x9, %9\n"
+        "str x10, %10\n"
+        "str x11, %11\n"
+        "str x12, %12\n"
+        "str x13, %13\n"
+        "str x14, %14\n"
+        : "+m"(X0),
+          "+m"(X1),
+          "+m"(X2),
+          "+m"(X3),
+          "+m"(X4),
+          "+m"(X5),
+          "+m"(X6),
+          "+m"(X7),
+          "+m"(X8),
+          "+m"(X9),
+          "+m"(X10),
+          "+m"(X11),
+          "+m"(X12),
+          "+m"(X13),
+          "+m"(X14)
+        :
+        : "w0", "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
+          "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17");
+
+    (*kern_ops).out.X0 = X0;
+    (*kern_ops).out.X1 = X1;
+    (*kern_ops).out.X2 = X2;
+    (*kern_ops).out.X3 = X3;
+    (*kern_ops).out.X4 = X4;
+    (*kern_ops).out.X5 = X5;
+    (*kern_ops).out.X6 = X6;
+    (*kern_ops).out.X7 = X7;
+    (*kern_ops).out.X8 = X8;
+    (*kern_ops).out.X9 = X9;
+    (*kern_ops).out.X10 = X10;
+    (*kern_ops).out.X11 = X11;
+    (*kern_ops).out.X12 = X12;
+    (*kern_ops).out.X13 = X13;
+    (*kern_ops).out.X14 = X14;
+
+    return (*kern_ops);
+}

--- a/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/hvc_inline.h
+++ b/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/hvc_inline.h
@@ -67,7 +67,7 @@ inline struct hvc_operands pal_execute_hvc_inline(struct hvc_operands * kern_ops
           "+m"(X13),
           "+m"(X14)
         :
-        : "w0", "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
+        : "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
           "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17");
 
     (*kern_ops).out.X0 = X0;

--- a/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/smc_inline.h
+++ b/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/smc_inline.h
@@ -1,0 +1,105 @@
+#include "devpal_abi_armv8a_aarch64.h"
+
+inline struct smc_operands pal_execute_smc_inline(struct smc_operands * kern_ops)
+{
+    // Note teh strange X0 W0 case here per ARM manual
+    uint64_t X0 = (*kern_ops).in.W0;
+    uint64_t X1 = (*kern_ops).in.X1;
+    uint64_t X2 = (*kern_ops).in.X2;
+    uint64_t X3 = (*kern_ops).in.X3;
+    uint64_t X4 = (*kern_ops).in.X4;
+    uint64_t X5 = (*kern_ops).in.X5;
+    uint64_t X6 = (*kern_ops).in.X6;
+    uint64_t X7 = (*kern_ops).in.X7;
+    uint64_t X8 = (*kern_ops).in.X8;
+    uint64_t X9 = (*kern_ops).in.X9;
+    uint64_t X10 = (*kern_ops).in.X10;
+    uint64_t X11 = (*kern_ops).in.X11;
+    uint64_t X12 = (*kern_ops).in.X12;
+    uint64_t X13 = (*kern_ops).in.X13;
+    uint64_t X14 = (*kern_ops).in.X14;
+    uint64_t X15 = (*kern_ops).in.X15;
+    uint64_t X16 = (*kern_ops).in.X16;
+    uint64_t X17 = (*kern_ops).in.X17;
+
+    __asm__ volatile(
+        "ldr w0, %0\n"
+        "ldr x1, %1\n"
+        "ldr x2, %2\n"
+        "ldr x3, %3\n"
+        "ldr x4, %4\n"
+        "ldr x5, %5\n"
+        "ldr x6, %6\n"
+        "ldr x7, %7\n"
+        "ldr x8, %8\n"
+        "ldr x9, %9\n"
+        "ldr x10, %10\n"
+        "ldr x11, %11\n"
+        "ldr x12, %12\n"
+        "ldr x13, %13\n"
+        "ldr x14, %14\n"
+        // "ldr x15, %15\n"
+        // "ldr x16, %16\n"
+        // "ldr x17, %17\n"
+        "smc #0\n"
+        "str x0, %0\n"
+        "str x1, %1\n"
+        "str x2, %2\n"
+        "str x3, %3\n"
+        "str x4, %4\n"
+        "str x5, %5\n"
+        "str x6, %6\n"
+        "str x7, %7\n"
+        "str x8, %8\n"
+        "str x9, %9\n"
+        "str x10, %10\n"
+        "str x11, %11\n"
+        "str x12, %12\n"
+        "str x13, %13\n"
+        "str x14, %14\n"
+        // "str x15, %15\n"
+        // "str x16, %16\n"
+        // "str x17, %17\n"
+        : "+m"(X0),
+          "+m"(X1),
+          "+m"(X2),
+          "+m"(X3),
+          "+m"(X4)
+          "+r"(X5),
+          "+r"(X6),
+          "+r"(X7),
+          "+r"(X8),
+          "+r"(X9),
+          "+r"(X10),
+          "+r"(X11),
+          "+r"(X12),
+          "+r"(X13),
+          "+r"(X14),
+        //   "+r"(X15),
+        //   "+r"(X16),
+        //   "+r"(X17)
+        :
+        : "w0", "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
+          "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17");
+
+    (*kern_ops).out.X0 = X0;
+    (*kern_ops).out.X1 = X1;
+    (*kern_ops).out.X2 = X2;
+    (*kern_ops).out.X3 = X3;
+    (*kern_ops).out.X4 = X4;
+    (*kern_ops).out.X5 = X5;
+    (*kern_ops).out.X6 = X6;
+    (*kern_ops).out.X7 = X7;
+    (*kern_ops).out.X8 = X8;
+    (*kern_ops).out.X9 = X9;
+    (*kern_ops).out.X10 = X10;
+    (*kern_ops).out.X11 = X11;
+    (*kern_ops).out.X12 = X12;
+    (*kern_ops).out.X13 = X13;
+    (*kern_ops).out.X14 = X14;
+    (*kern_ops).out.X15 = X15;
+    (*kern_ops).out.X16 = X16;
+    (*kern_ops).out.X17 = X17;
+
+    return (*kern_ops);
+}

--- a/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/smc_inline.h
+++ b/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/smc_inline.h
@@ -67,7 +67,7 @@ inline struct smc_operands pal_execute_smc_inline(struct smc_operands * kern_ops
           "+m"(X13),
           "+m"(X14)
         :
-        : "w0", "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
+        : "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
           "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17");
 
     (*kern_ops).out.X0 = X0;

--- a/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/smc_inline.h
+++ b/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/smc_inline.h
@@ -18,9 +18,6 @@ inline struct smc_operands pal_execute_smc_inline(struct smc_operands * kern_ops
     uint64_t X12 = (*kern_ops).in.X12;
     uint64_t X13 = (*kern_ops).in.X13;
     uint64_t X14 = (*kern_ops).in.X14;
-    uint64_t X15 = (*kern_ops).in.X15;
-    uint64_t X16 = (*kern_ops).in.X16;
-    uint64_t X17 = (*kern_ops).in.X17;
 
     __asm__ volatile(
         "ldr w0, %0\n"
@@ -38,9 +35,6 @@ inline struct smc_operands pal_execute_smc_inline(struct smc_operands * kern_ops
         "ldr x12, %12\n"
         "ldr x13, %13\n"
         "ldr x14, %14\n"
-        // "ldr x15, %15\n"
-        // "ldr x16, %16\n"
-        // "ldr x17, %17\n"
         "smc #0\n"
         "str x0, %0\n"
         "str x1, %1\n"
@@ -57,27 +51,21 @@ inline struct smc_operands pal_execute_smc_inline(struct smc_operands * kern_ops
         "str x12, %12\n"
         "str x13, %13\n"
         "str x14, %14\n"
-        // "str x15, %15\n"
-        // "str x16, %16\n"
-        // "str x17, %17\n"
         : "+m"(X0),
           "+m"(X1),
           "+m"(X2),
           "+m"(X3),
-          "+m"(X4)
-          "+r"(X5),
-          "+r"(X6),
-          "+r"(X7),
-          "+r"(X8),
-          "+r"(X9),
-          "+r"(X10),
-          "+r"(X11),
-          "+r"(X12),
-          "+r"(X13),
-          "+r"(X14),
-        //   "+r"(X15),
-        //   "+r"(X16),
-        //   "+r"(X17)
+          "+m"(X4),
+          "+m"(X5),
+          "+m"(X6),
+          "+m"(X7),
+          "+m"(X8),
+          "+m"(X9),
+          "+m"(X10),
+          "+m"(X11),
+          "+m"(X12),
+          "+m"(X13),
+          "+m"(X14)
         :
         : "w0", "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
           "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17");
@@ -97,9 +85,6 @@ inline struct smc_operands pal_execute_smc_inline(struct smc_operands * kern_ops
     (*kern_ops).out.X12 = X12;
     (*kern_ops).out.X13 = X13;
     (*kern_ops).out.X14 = X14;
-    (*kern_ops).out.X15 = X15;
-    (*kern_ops).out.X16 = X16;
-    (*kern_ops).out.X17 = X17;
 
     return (*kern_ops);
 }

--- a/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/sys_inline.h
+++ b/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/sys_inline.h
@@ -1,0 +1,3192 @@
+inline void pal_set_actlr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c1_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_actlr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c1_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_actlr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c1_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_afsr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_afsr0_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c5_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_afsr0_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c5_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_afsr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c1_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_afsr1_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c5_c1_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_afsr1_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c5_c1_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_aidr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_1_c0_c0_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amair_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c10_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amair_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amair_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c10_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amcfgr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c2_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amcgcr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c2_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amcntenclr0_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c2_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amcntenclr1_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amcntenset0_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c2_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amcntenset1_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c3_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amcr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr00_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c4_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr010_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c5_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr011_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c5_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr012_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c5_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr013_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c5_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr014_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c5_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr015_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c5_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr01_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c4_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr02_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c4_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr03_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c4_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr04_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c4_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr05_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c4_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr06_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c4_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr07_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c4_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr08_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr09_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c5_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr10_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c12_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr110_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c13_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr111_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c13_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr112_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c13_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr113_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c13_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr114_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c13_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr115_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c13_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr11_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c12_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr12_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c12_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr13_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c12_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr14_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c12_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr15_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c12_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr16_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c12_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr17_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c12_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr18_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c13_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevcntr19_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c13_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper00_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c6_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper010_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c7_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper011_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c7_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper012_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c7_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper013_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c7_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper014_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c7_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper015_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c7_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper01_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c6_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper02_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c6_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper03_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c6_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper04_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c6_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper05_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c6_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper06_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c6_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper07_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c6_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper08_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c7_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper09_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c7_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper10_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c14_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper110_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c15_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper111_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c15_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper112_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c15_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper113_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c15_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper114_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c15_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper115_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c15_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper11_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c14_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper12_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c14_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper13_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c14_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper14_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c14_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper15_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c14_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper16_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c14_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper17_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c14_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper18_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c15_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amevtyper19_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c15_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_amuserenr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c2_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_apdakeyhi_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c2_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_apdakeylo_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_apdbkeyhi_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c2_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_apdbkeylo_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c2_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_apgakeyhi_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c3_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_apgakeylo_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_apiakeyhi_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c1_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_apiakeylo_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_apibkeyhi_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c1_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_apibkeylo_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c1_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ccsidr2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_1_c0_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ccsidr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_1_c0_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_clidr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_1_c0_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntfrq_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthctl_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthp_ctl_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c2_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthp_cval_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c2_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthp_tval_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthps_ctl_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c5_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthps_cval_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c5_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthps_tval_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthv_ctl_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c3_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthv_cval_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c3_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthv_tval_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthvs_ctl_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c4_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthvs_cval_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c4_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cnthvs_tval_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c4_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntkctl_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c14_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntp_ctl_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c2_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntp_cval_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c2_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntp_tval_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntpct_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntps_ctl_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_7_c14_c2_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntps_cval_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_7_c14_c2_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntps_tval_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_7_c14_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntv_ctl_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c3_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntv_cval_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c3_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntv_tval_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntvct_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cntvoff_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c14_c0_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_contextidr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c13_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_contextidr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c13_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cpacr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c1_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cptr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c1_c1_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_cptr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c1_c1_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_csselr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_2_c0_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ctr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c0_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_currentel_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c4_c2_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dacr32_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c3_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_daif_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c4_c2_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgauthstatus_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c7_c14_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c0_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr10_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c10_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr11_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c11_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr12_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c12_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr13_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c13_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr14_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c14_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr15_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c15_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c1_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c2_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr3_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c3_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr4_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c4_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr5_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c5_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr6_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c6_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr7_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c7_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr8_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c8_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbcr9_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c9_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c0_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr10_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c10_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr11_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c11_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr12_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c12_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr13_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c13_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr14_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c14_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr15_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c15_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c1_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c2_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr3_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c3_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr4_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c4_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr5_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c5_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr6_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c6_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr7_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c7_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr8_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c8_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgbvr9_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c9_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgclaimclr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c7_c9_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgclaimset_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c7_c8_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgdtr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_3_c0_c4_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgdtrrx_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_3_c0_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgprcr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c1_c4_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgvcr32_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_4_c0_c7_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c0_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr10_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c10_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr11_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c11_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr12_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c12_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr13_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c13_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr14_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c14_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr15_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c15_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c1_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c2_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr3_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c3_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr4_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c4_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr5_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c5_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr6_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c6_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr7_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c7_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr8_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c8_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwcr9_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c9_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c0_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr10_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c10_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr11_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c11_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr12_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c12_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr13_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c13_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr14_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c14_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr15_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c15_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c1_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c2_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr3_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c3_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr4_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c4_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr5_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c5_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr6_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c6_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr7_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c7_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr8_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c8_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dbgwvr9_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c9_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dczid_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c0_c0_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_disr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c1_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dit_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c4_c2_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dlr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c4_c5_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_dspsr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c4_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_elr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c4_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_elr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c4_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_elr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c4_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erridr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_errselr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c3_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxaddr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c4_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxctlr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c4_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxfr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c4_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxmisc0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxmisc1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c5_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxmisc2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c5_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxmisc3_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c5_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxpfgcdn_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c4_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxpfgctl_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c4_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxpfgf_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c4_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_erxstatus_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c4_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_esr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c5_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_esr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c5_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_esr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c5_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_far_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c6_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_far_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c6_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_far_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c6_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_fpcr_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c4_c4_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_fpexc32_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c5_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_fpsr_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c4_c4_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_gcr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c1_c0_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_hacr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c1_c1_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_hcr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c1_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_hpfar_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c6_c0_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_hstr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c1_c1_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_ap0r0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c8_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_ap0r1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c8_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_ap0r2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c8_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_ap0r3_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c8_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_ap1r0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c9_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_ap1r1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c9_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_ap1r2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c9_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_ap1r3_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c9_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_asgi1r_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c11_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_bpr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c8_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_bpr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c12_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_ctlr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c12_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_ctlr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c12_c12_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_dir_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c11_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_eoir0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c8_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_eoir1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c12_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_hppir0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c8_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_hppir1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c12_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_iar0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c8_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_iar1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c12_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_igrpen0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c12_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_igrpen1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c12_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_igrpen1_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c12_c12_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_pmr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c4_c6_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_rpr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c11_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_sgi0r_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c11_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_sgi1r_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c11_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_sre_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c12_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_sre_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c9_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_icc_sre_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c12_c12_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_ap0r0_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c8_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_ap0r1_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c8_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_ap0r2_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c8_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_ap0r3_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c8_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_ap1r0_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c9_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_ap1r1_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c9_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_ap1r2_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c9_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_ap1r3_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c9_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_eisr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c11_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_elrsr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c11_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_hcr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c11_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr0_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c12_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr10_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c13_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr11_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c13_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr12_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c13_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr13_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c13_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr14_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c13_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr15_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c13_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr1_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c12_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr2_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c12_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr3_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c12_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr4_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c12_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr5_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c12_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr6_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c12_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr7_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c12_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr8_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c13_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_lr9_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c13_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_misr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c11_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_vmcr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c11_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ich_vtr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c11_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64afr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c5_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64afr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c5_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64dfr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64dfr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c5_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64isar0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c6_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64isar1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c6_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64mmfr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c7_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64mmfr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c7_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64mmfr2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c7_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64pfr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c4_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64pfr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c4_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_aa64zfr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c4_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_afr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c1_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_dfr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c1_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_isar0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_isar1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c2_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_isar2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c2_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_isar3_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c2_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_isar4_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c2_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_isar5_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c2_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_isar6_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c2_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_mmfr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c1_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_mmfr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c1_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_mmfr2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c1_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_mmfr3_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c1_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_mmfr4_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c2_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_pfr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_pfr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c1_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_id_pfr2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c3_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ifsr32_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c5_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_isr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_lorc_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c10_c4_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_lorea_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c10_c4_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_lorid_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c10_c4_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_lorn_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c10_c4_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_lorsa_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c10_c4_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mair_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c10_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mair_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mair_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c10_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mdccint_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mdccsr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_3_c0_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mdcr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c1_c1_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mdcr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c1_c3_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mdrar_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c1_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mdscr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c2_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_midr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpam0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c10_c5_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpam1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c10_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpam2_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpam3_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c10_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamhcr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c4_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamidr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c10_c4_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamvpm0_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c6_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamvpm1_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c6_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamvpm2_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c6_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamvpm3_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c6_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamvpm4_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c6_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamvpm5_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c6_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamvpm6_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c6_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamvpm7_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c6_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpamvpmv_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c10_c4_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mpidr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c0_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mvfr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mvfr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c3_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_mvfr2_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c3_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_nzcv_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c4_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_osdlr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c1_c3_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_osdtrrx_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_osdtrtx_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c3_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_oseccr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c0_c6_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_oslar_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c1_c0_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_oslsr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s2_0_c1_c1_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pan_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c4_c2_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_par_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c7_c4_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmbidr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c10_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmblimitr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c10_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmbptr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c10_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmbsr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c10_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmccfiltr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c15_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmccntr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c13_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmceid0_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c12_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmceid1_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c12_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmcntenclr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c12_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmcntenset_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c12_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmcr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c12_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr0_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c8_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr10_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c9_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr11_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c9_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr12_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c9_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr13_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c9_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr14_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c9_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr15_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c9_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr16_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c10_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr17_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c10_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr18_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c10_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr19_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c10_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr1_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c8_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr20_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c10_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr21_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c10_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr22_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c10_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr23_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c10_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr24_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c11_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr25_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c11_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr26_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c11_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr27_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c11_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr28_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c11_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr29_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c11_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr2_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c8_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr30_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c11_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr3_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c8_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr4_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c8_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr5_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c8_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr6_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c8_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr7_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c8_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr8_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c9_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevcntr9_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c9_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper0_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c12_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper10_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c13_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper11_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c13_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper12_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c13_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper13_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c13_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper14_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c13_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper15_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c13_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper16_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c14_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper17_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c14_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper18_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c14_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper19_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c14_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper1_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c12_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper20_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c14_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper21_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c14_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper22_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c14_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper23_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c14_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper24_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c15_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper25_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c15_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper26_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c15_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper27_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c15_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper28_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c15_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper29_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c15_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper2_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c12_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper30_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c15_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper3_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c12_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper4_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c12_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper5_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c12_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper6_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c12_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper7_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c12_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper8_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c13_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmevtyper9_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c14_c13_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmintenclr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c14_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmintenset_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c14_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmmir_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c14_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmovsclr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c12_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmovsset_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c14_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmscr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c9_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmscr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c9_c9_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmselr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c12_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmsevfr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c9_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmsfcr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c9_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmsicr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c9_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmsidr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c9_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmsirr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c9_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmslatfr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c9_c9_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmswinc_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c12_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmuserenr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c14_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmxevcntr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c13_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_pmxevtyper_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c9_c13_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_revidr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c0_c0_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_rgsr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c1_c0_5, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_rmr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_rmr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_rmr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c12_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_rndr_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c2_c4_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_rndrrs_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c2_c4_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_rvbar_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_rvbar_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_rvbar_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c12_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_scr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c1_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_sctlr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c1_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_sctlr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c1_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_sctlr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c1_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_scxtnum_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c0_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_scxtnum_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c13_c0_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_scxtnum_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c13_c0_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_scxtnum_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c13_c0_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_sder32_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c1_c3_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_sder32_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c1_c1_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_sp_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c4_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_sp_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c4_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_sp_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c4_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_spsel_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c4_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_spsr_abt_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c4_c3_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_spsr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c4_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_spsr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c4_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_spsr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c4_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_spsr_fiq_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c4_c3_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_spsr_irq_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c4_c3_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_spsr_und_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c4_c3_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ssbs_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c4_c2_6, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tco_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c4_c2_7, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tcr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tcr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c2_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tcr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c2_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tfsr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c6_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tfsr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c6_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tfsr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c6_c5_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tfsre0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c6_c6_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tpidr_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tpidr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c13_c0_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tpidr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c13_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tpidr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c13_c0_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_tpidrro_el0_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_3_c13_c0_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_trfcr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c1_c2_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_trfcr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c1_c2_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ttbr0_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ttbr0_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c2_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ttbr0_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c2_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ttbr1_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c2_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_ttbr1_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c2_c0_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_uao_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c4_c2_4, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_vbar_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c12_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_vbar_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_vbar_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c12_c0_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_vdisr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c12_c1_1, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_vncr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c2_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_vsesr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c5_c2_3, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_vstcr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c2_c6_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_vsttbr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c2_c6_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_vtcr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c2_c1_2, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_vttbr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c2_c1_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_zcr_el1_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_0_c1_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_zcr_el2_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_4_c1_c2_0, %0"
+			:
+			: "r"(value));
+}
+inline void pal_set_zcr_el3_inline(uint64_t value)
+{
+	__asm__ volatile("msr s3_6_c1_c2_0, %0"
+			:
+			: "r"(value));
+}

--- a/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/sysl_inline.h
+++ b/libpal/armv8a_aarch64_aapcs64_gnuinline/include/pal/aarch64/sysl_inline.h
@@ -1,0 +1,3682 @@
+inline uint64_t pal_get_actlr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c1_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_actlr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c1_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_actlr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c1_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_afsr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_afsr0_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c5_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_afsr0_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c5_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_afsr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c1_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_afsr1_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c5_c1_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_afsr1_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c5_c1_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_aidr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_1_c0_c0_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amair_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c10_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amair_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amair_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c10_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amcfgr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c2_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amcgcr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c2_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amcntenclr0_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c2_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amcntenclr1_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amcntenset0_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c2_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amcntenset1_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c3_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amcr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr00_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c4_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr010_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c5_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr011_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c5_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr012_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c5_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr013_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c5_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr014_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c5_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr015_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c5_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr01_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c4_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr02_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c4_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr03_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c4_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr04_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c4_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr05_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c4_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr06_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c4_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr07_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c4_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr08_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr09_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c5_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr10_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c12_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr110_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c13_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr111_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c13_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr112_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c13_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr113_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c13_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr114_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c13_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr115_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c13_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr11_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c12_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr12_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c12_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr13_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c12_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr14_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c12_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr15_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c12_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr16_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c12_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr17_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c12_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr18_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c13_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevcntr19_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c13_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper00_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c6_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper010_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c7_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper011_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c7_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper012_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c7_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper013_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c7_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper014_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c7_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper015_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c7_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper01_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c6_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper02_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c6_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper03_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c6_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper04_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c6_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper05_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c6_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper06_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c6_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper07_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c6_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper08_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c7_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper09_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c7_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper10_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c14_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper110_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c15_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper111_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c15_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper112_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c15_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper113_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c15_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper114_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c15_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper115_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c15_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper11_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c14_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper12_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c14_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper13_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c14_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper14_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c14_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper15_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c14_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper16_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c14_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper17_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c14_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper18_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c15_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amevtyper19_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c15_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_amuserenr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c2_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_apdakeyhi_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c2_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_apdakeylo_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_apdbkeyhi_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c2_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_apdbkeylo_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c2_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_apgakeyhi_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c3_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_apgakeylo_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_apiakeyhi_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c1_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_apiakeylo_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_apibkeyhi_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c1_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_apibkeylo_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c1_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ccsidr2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_1_c0_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ccsidr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_1_c0_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_clidr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_1_c0_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntfrq_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthctl_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthp_ctl_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c2_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthp_cval_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c2_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthp_tval_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthps_ctl_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c5_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthps_cval_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c5_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthps_tval_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthv_ctl_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c3_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthv_cval_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c3_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthv_tval_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthvs_ctl_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c4_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthvs_cval_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c4_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cnthvs_tval_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c4_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntkctl_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c14_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntp_ctl_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c2_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntp_cval_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c2_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntp_tval_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntpct_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntps_ctl_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_7_c14_c2_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntps_cval_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_7_c14_c2_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntps_tval_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_7_c14_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntv_ctl_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c3_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntv_cval_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c3_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntv_tval_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntvct_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cntvoff_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c14_c0_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_contextidr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c13_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_contextidr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c13_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cpacr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c1_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cptr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c1_c1_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_cptr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c1_c1_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_csselr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_2_c0_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ctr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c0_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_currentel_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c4_c2_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dacr32_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c3_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_daif_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c4_c2_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgauthstatus_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c7_c14_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c0_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr10_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c10_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr11_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c11_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr12_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c12_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr13_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c13_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr14_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c14_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr15_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c15_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c1_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c2_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr3_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c3_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr4_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c4_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr5_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c5_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr6_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c6_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr7_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c7_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr8_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c8_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbcr9_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c9_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c0_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr10_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c10_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr11_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c11_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr12_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c12_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr13_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c13_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr14_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c14_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr15_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c15_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c1_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c2_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr3_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c3_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr4_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c4_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr5_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c5_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr6_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c6_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr7_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c7_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr8_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c8_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgbvr9_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c9_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgclaimclr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c7_c9_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgclaimset_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c7_c8_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgdtr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_3_c0_c4_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgdtrrx_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_3_c0_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgprcr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c1_c4_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgvcr32_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_4_c0_c7_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c0_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr10_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c10_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr11_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c11_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr12_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c12_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr13_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c13_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr14_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c14_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr15_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c15_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c1_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c2_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr3_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c3_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr4_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c4_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr5_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c5_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr6_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c6_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr7_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c7_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr8_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c8_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwcr9_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c9_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c0_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr10_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c10_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr11_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c11_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr12_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c12_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr13_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c13_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr14_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c14_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr15_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c15_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c1_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c2_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr3_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c3_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr4_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c4_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr5_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c5_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr6_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c6_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr7_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c7_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr8_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c8_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dbgwvr9_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c9_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dczid_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c0_c0_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_disr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c1_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dit_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c4_c2_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dlr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c4_c5_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_dspsr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c4_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_elr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c4_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_elr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c4_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_elr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c4_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erridr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_errselr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c3_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxaddr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c4_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxctlr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c4_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxfr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c4_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxmisc0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxmisc1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c5_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxmisc2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c5_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxmisc3_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c5_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxpfgcdn_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c4_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxpfgctl_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c4_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxpfgf_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c4_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_erxstatus_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c4_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_esr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c5_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_esr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c5_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_esr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c5_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_far_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c6_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_far_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c6_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_far_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c6_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_fpcr_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c4_c4_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_fpexc32_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c5_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_fpsr_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c4_c4_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_gcr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c1_c0_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_hacr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c1_c1_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_hcr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c1_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_hpfar_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c6_c0_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_hstr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c1_c1_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_ap0r0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c8_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_ap0r1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c8_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_ap0r2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c8_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_ap0r3_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c8_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_ap1r0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c9_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_ap1r1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c9_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_ap1r2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c9_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_ap1r3_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c9_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_bpr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c8_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_bpr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c12_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_ctlr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c12_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_ctlr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c12_c12_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_hppir0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c8_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_hppir1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c12_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_iar0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c8_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_iar1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c12_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_igrpen0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c12_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_igrpen1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c12_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_igrpen1_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c12_c12_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_pmr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c4_c6_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_rpr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c11_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_sre_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c12_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_sre_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c9_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_icc_sre_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c12_c12_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_ap0r0_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c8_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_ap0r1_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c8_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_ap0r2_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c8_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_ap0r3_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c8_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_ap1r0_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c9_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_ap1r1_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c9_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_ap1r2_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c9_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_ap1r3_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c9_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_eisr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c11_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_elrsr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c11_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_hcr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c11_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr0_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c12_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr10_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c13_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr11_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c13_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr12_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c13_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr13_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c13_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr14_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c13_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr15_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c13_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr1_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c12_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr2_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c12_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr3_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c12_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr4_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c12_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr5_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c12_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr6_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c12_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr7_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c12_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr8_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c13_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_lr9_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c13_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_misr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c11_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_vmcr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c11_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ich_vtr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c11_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64afr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c5_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64afr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c5_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64dfr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64dfr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c5_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64isar0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c6_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64isar1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c6_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64mmfr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c7_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64mmfr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c7_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64mmfr2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c7_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64pfr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c4_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64pfr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c4_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_aa64zfr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c4_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_afr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c1_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_dfr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c1_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_isar0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_isar1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c2_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_isar2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c2_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_isar3_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c2_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_isar4_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c2_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_isar5_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c2_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_isar6_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c2_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_mmfr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c1_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_mmfr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c1_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_mmfr2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c1_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_mmfr3_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c1_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_mmfr4_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c2_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_pfr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_pfr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c1_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_id_pfr2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c3_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ifsr32_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c5_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_isr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_lorc_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c10_c4_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_lorea_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c10_c4_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_lorid_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c10_c4_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_lorn_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c10_c4_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_lorsa_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c10_c4_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mair_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c10_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mair_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mair_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c10_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mdccint_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mdccsr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_3_c0_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mdcr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c1_c1_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mdcr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c1_c3_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mdrar_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c1_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mdscr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c2_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_midr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpam0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c10_c5_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpam1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c10_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpam2_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpam3_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c10_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamhcr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c4_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamidr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c10_c4_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamvpm0_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c6_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamvpm1_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c6_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamvpm2_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c6_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamvpm3_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c6_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamvpm4_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c6_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamvpm5_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c6_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamvpm6_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c6_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamvpm7_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c6_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpamvpmv_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c10_c4_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mpidr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c0_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mvfr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mvfr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c3_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_mvfr2_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c3_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_nzcv_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c4_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_osdlr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c1_c3_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_osdtrrx_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_osdtrtx_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c3_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_oseccr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c0_c6_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_oslsr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s2_0_c1_c1_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pan_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c4_c2_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_par_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c7_c4_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmbidr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c10_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmblimitr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c10_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmbptr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c10_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmbsr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c10_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmccfiltr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c15_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmccntr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c13_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmceid0_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c12_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmceid1_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c12_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmcntenclr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c12_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmcntenset_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c12_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmcr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c12_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr0_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c8_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr10_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c9_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr11_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c9_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr12_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c9_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr13_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c9_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr14_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c9_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr15_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c9_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr16_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c10_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr17_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c10_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr18_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c10_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr19_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c10_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr1_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c8_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr20_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c10_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr21_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c10_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr22_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c10_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr23_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c10_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr24_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c11_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr25_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c11_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr26_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c11_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr27_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c11_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr28_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c11_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr29_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c11_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr2_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c8_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr30_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c11_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr3_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c8_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr4_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c8_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr5_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c8_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr6_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c8_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr7_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c8_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr8_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c9_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevcntr9_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c9_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper0_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c12_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper10_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c13_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper11_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c13_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper12_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c13_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper13_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c13_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper14_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c13_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper15_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c13_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper16_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c14_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper17_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c14_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper18_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c14_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper19_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c14_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper1_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c12_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper20_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c14_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper21_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c14_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper22_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c14_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper23_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c14_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper24_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c15_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper25_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c15_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper26_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c15_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper27_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c15_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper28_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c15_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper29_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c15_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper2_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c12_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper30_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c15_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper3_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c12_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper4_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c12_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper5_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c12_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper6_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c12_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper7_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c12_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper8_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c13_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmevtyper9_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c14_c13_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmintenclr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c14_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmintenset_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c14_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmmir_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c14_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmovsclr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c12_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmovsset_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c14_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmscr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c9_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmscr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c9_c9_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmselr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c12_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmsevfr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c9_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmsfcr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c9_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmsicr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c9_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmsidr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c9_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmsirr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c9_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmslatfr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c9_c9_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmuserenr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c14_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmxevcntr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c13_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_pmxevtyper_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c9_c13_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_revidr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c0_c0_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_rgsr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c1_c0_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_rmr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_rmr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_rmr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c12_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_rndr_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c2_c4_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_rndrrs_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c2_c4_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_rvbar_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_rvbar_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_rvbar_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c12_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_scr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c1_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_sctlr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c1_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_sctlr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c1_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_sctlr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c1_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_scxtnum_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c0_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_scxtnum_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c13_c0_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_scxtnum_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c13_c0_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_scxtnum_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c13_c0_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_sder32_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c1_c3_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_sder32_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c1_c1_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_sp_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c4_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_sp_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c4_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_sp_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c4_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_spsel_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c4_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_spsr_abt_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c4_c3_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_spsr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c4_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_spsr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c4_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_spsr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c4_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_spsr_fiq_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c4_c3_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_spsr_irq_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c4_c3_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_spsr_und_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c4_c3_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ssbs_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c4_c2_6"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tco_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c4_c2_7"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tcr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tcr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c2_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tcr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c2_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tfsr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c6_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tfsr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c6_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tfsr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c6_c5_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tfsre0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c6_c6_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tpidr_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tpidr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c13_c0_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tpidr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c13_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tpidr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c13_c0_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_tpidrro_el0_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_3_c13_c0_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_trfcr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c1_c2_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_trfcr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c1_c2_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ttbr0_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ttbr0_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c2_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ttbr0_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c2_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ttbr1_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c2_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_ttbr1_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c2_c0_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_uao_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c4_c2_4"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vbar_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c12_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vbar_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vbar_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c12_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vdisr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c12_c1_1"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vmpidr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c0_c0_5"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vncr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c2_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vpidr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c0_c0_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vsesr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c5_c2_3"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vstcr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c2_c6_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vsttbr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c2_c6_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vtcr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c2_c1_2"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_vttbr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c2_c1_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_zcr_el1_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_0_c1_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_zcr_el2_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_4_c1_c2_0"
+                     : "=r"(value));
+    return value;
+}
+inline uint64_t pal_get_zcr_el3_inline(void)
+{
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, s3_6_c1_c2_0"
+                     : "=r"(value));
+    return value;
+}

--- a/libpal/armv8a_aarch64_linux_ioctl/CMakeLists.txt
+++ b/libpal/armv8a_aarch64_linux_ioctl/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(pal_armv8a_aarch64_linux_ioctl PRIVATE
     sys.c
     sysl.c
     smc.c
+    hvc.c
 )

--- a/libpal/armv8a_aarch64_linux_ioctl/CMakeLists.txt
+++ b/libpal/armv8a_aarch64_linux_ioctl/CMakeLists.txt
@@ -6,4 +6,5 @@ target_include_directories(pal_armv8a_aarch64_linux_ioctl PRIVATE
 target_sources(pal_armv8a_aarch64_linux_ioctl PRIVATE
     sys.c
     sysl.c
+    smc.c
 )

--- a/libpal/armv8a_aarch64_linux_ioctl/CMakeLists.txt
+++ b/libpal/armv8a_aarch64_linux_ioctl/CMakeLists.txt
@@ -8,4 +8,12 @@ target_sources(pal_armv8a_aarch64_linux_ioctl PRIVATE
     sysl.c
     smc.c
     hvc.c
+    read_mem16.c
+    read_mem32.c
+    read_mem64.c
+    read_mem8.c
+    write_mem16.c   
+    write_mem32.c
+    write_mem64.c
+    write_mem8.c
 )

--- a/libpal/armv8a_aarch64_linux_ioctl/hvc.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/hvc.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "devpal_abi_armv8a_aarch64.h"
+
+#define DEVICE_FILE_NAME "/dev/devpal"
+
+struct hvc_operands pal_execute_hvc(struct hvc_operands *user_ops)
+{
+    int file_desc;
+    int status;
+    struct hvc_operands hvc_ops = {0};
+
+    file_desc = open(DEVICE_FILE_NAME, 0);
+    if (file_desc < 0)
+    {
+        printf("[libpal] Can't open device file: %s\n", DEVICE_FILE_NAME);
+        return hvc_ops;
+    }
+
+    hvc_ops.in.W0 = (*user_ops).in.W0;
+    hvc_ops.in.X1 = (*user_ops).in.X1;
+    hvc_ops.in.X2 = (*user_ops).in.X2;
+    hvc_ops.in.X3 = (*user_ops).in.X3;
+    hvc_ops.in.X4 = (*user_ops).in.X4;
+    hvc_ops.in.X5 = (*user_ops).in.X5;
+    hvc_ops.in.X6 = (*user_ops).in.X6;
+    hvc_ops.in.X7 = (*user_ops).in.X7;
+    hvc_ops.in.X8 = (*user_ops).in.X8;
+    hvc_ops.in.X9 = (*user_ops).in.X9;
+    hvc_ops.in.X10 = (*user_ops).in.X10;
+    hvc_ops.in.X11 = (*user_ops).in.X11;
+    hvc_ops.in.X12 = (*user_ops).in.X12;
+    hvc_ops.in.X13 = (*user_ops).in.X13;
+    hvc_ops.in.X14 = (*user_ops).in.X14;
+    
+    if (ioctl(file_desc, DEVPAL_EXECUTE_HVC, &hvc_ops))
+    {
+        printf("[libpal] hvc ioctl failed\n");
+        return hvc_ops;
+    }
+
+    return hvc_ops;
+}

--- a/libpal/armv8a_aarch64_linux_ioctl/read_mem16.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/read_mem16.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "devpal_abi_generic.h"
+
+#define DEVICE_FILE_NAME "/dev/devpal"
+
+uint16_t pal_execute_read_mem16(uint64_t address)
+{
+    int file_desc;
+    int status;
+    struct read_mem16_operands read_mem16_ops = {0};
+
+    file_desc = open(DEVICE_FILE_NAME, 0);
+    if (file_desc < 0) {
+        printf("[libpal] Can't open device file: %s\n", DEVICE_FILE_NAME);
+        return -1;
+    }
+
+    read_mem16_ops.in.address = address;
+    if(ioctl(file_desc, DEVPAL_EXECUTE_READ_MEM16, &read_mem16_ops)) {
+        printf("[libpal] read_mem16 ioctl failed\n");
+        return -1;
+    }
+
+    return read_mem16_ops.out.value;
+}

--- a/libpal/armv8a_aarch64_linux_ioctl/read_mem32.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/read_mem32.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "devpal_abi_generic.h"
+
+#define DEVICE_FILE_NAME "/dev/devpal"
+
+uint32_t pal_execute_read_mem32(uint64_t address)
+{
+    int file_desc;
+    int status;
+    struct read_mem32_operands read_mem32_ops = {0};
+
+    file_desc = open(DEVICE_FILE_NAME, 0);
+    if (file_desc < 0) {
+        printf("[libpal] Can't open device file: %s\n", DEVICE_FILE_NAME);
+        return -1;
+    }
+
+    read_mem32_ops.in.address = address;
+    if(ioctl(file_desc, DEVPAL_EXECUTE_READ_MEM32, &read_mem32_ops)) {
+        printf("[libpal] read_mem32 ioctl failed\n");
+        return -1;
+    }
+
+    return read_mem32_ops.out.value;
+}

--- a/libpal/armv8a_aarch64_linux_ioctl/read_mem64.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/read_mem64.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "devpal_abi_generic.h"
+
+#define DEVICE_FILE_NAME "/dev/devpal"
+
+uint64_t pal_execute_read_mem64(uint64_t address)
+{
+    int file_desc;
+    int status;
+    struct read_mem64_operands read_mem64_ops = {0};
+
+    file_desc = open(DEVICE_FILE_NAME, 0);
+    if (file_desc < 0) {
+        printf("[libpal] Can't open device file: %s\n", DEVICE_FILE_NAME);
+        return -1;
+    }
+
+    read_mem64_ops.in.address = address;
+    if(ioctl(file_desc, DEVPAL_EXECUTE_READ_MEM64, &read_mem64_ops)) {
+        printf("[libpal] read_mem64 ioctl failed\n");
+        return -1;
+    }
+
+    return read_mem64_ops.out.value;
+}

--- a/libpal/armv8a_aarch64_linux_ioctl/read_mem8.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/read_mem8.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "devpal_abi_generic.h"
+
+#define DEVICE_FILE_NAME "/dev/devpal"
+
+uint8_t pal_execute_read_mem8(uint64_t address)
+{
+    int file_desc;
+    int status;
+    struct read_mem8_operands read_mem8_ops = {0};
+
+    file_desc = open(DEVICE_FILE_NAME, 0);
+    if (file_desc < 0) {
+        printf("[libpal] Can't open device file: %s\n", DEVICE_FILE_NAME);
+        return -1;
+    }
+
+    read_mem8_ops.in.address = address;
+    if(ioctl(file_desc, DEVPAL_EXECUTE_READ_MEM8, &read_mem8_ops)) {
+        printf("[libpal] read_mem8 ioctl failed\n");
+        return -1;
+    }
+
+    return read_mem8_ops.out.value;
+}

--- a/libpal/armv8a_aarch64_linux_ioctl/smc.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/smc.c
@@ -35,9 +35,6 @@ struct smc_operands pal_execute_smc(struct smc_operands *user_ops)
     smc_ops.in.X12 = (*user_ops).in.X12;
     smc_ops.in.X13 = (*user_ops).in.X13;
     smc_ops.in.X14 = (*user_ops).in.X14;
-    smc_ops.in.X15 = (*user_ops).in.X15;
-    smc_ops.in.X16 = (*user_ops).in.X16;
-    smc_ops.in.X17 = (*user_ops).in.X17;
     
     if (ioctl(file_desc, DEVPAL_EXECUTE_SMC, &smc_ops))
     {

--- a/libpal/armv8a_aarch64_linux_ioctl/smc.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/smc.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "devpal_abi_armv8a_aarch64.h"
+
+#define DEVICE_FILE_NAME "/dev/devpal"
+
+struct smc_operands pal_execute_smc(struct smc_operands *user_ops)
+{
+    int file_desc;
+    int status;
+    struct smc_operands smc_ops = {0};
+
+    file_desc = open(DEVICE_FILE_NAME, 0);
+    if (file_desc < 0)
+    {
+        printf("[libpal] Can't open device file: %s\n", DEVICE_FILE_NAME);
+        return smc_ops;
+    }
+
+    smc_ops.in.W0 = (*user_ops).in.W0;
+    smc_ops.in.X1 = (*user_ops).in.X1;
+    smc_ops.in.X2 = (*user_ops).in.X2;
+    smc_ops.in.X3 = (*user_ops).in.X3;
+    smc_ops.in.X4 = (*user_ops).in.X4;
+    smc_ops.in.X5 = (*user_ops).in.X5;
+    smc_ops.in.X6 = (*user_ops).in.X6;
+    smc_ops.in.X7 = (*user_ops).in.X7;
+    smc_ops.in.X8 = (*user_ops).in.X8;
+    smc_ops.in.X9 = (*user_ops).in.X9;
+    smc_ops.in.X10 = (*user_ops).in.X10;
+    smc_ops.in.X11 = (*user_ops).in.X11;
+    smc_ops.in.X12 = (*user_ops).in.X12;
+    smc_ops.in.X13 = (*user_ops).in.X13;
+    smc_ops.in.X14 = (*user_ops).in.X14;
+    smc_ops.in.X15 = (*user_ops).in.X15;
+    smc_ops.in.X16 = (*user_ops).in.X16;
+    smc_ops.in.X17 = (*user_ops).in.X17;
+    
+    if (ioctl(file_desc, DEVPAL_EXECUTE_SMC, &smc_ops))
+    {
+        printf("[libpal] smc ioctl failed\n");
+        return smc_ops;
+    }
+
+    return smc_ops;
+}

--- a/libpal/armv8a_aarch64_linux_ioctl/sys.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/sys.c
@@ -7,7 +7,7 @@
 
 #define DEVICE_FILE_NAME "/dev/devpal"
 
-void pal_execute_sys(uint8_t op1, uint8_t crn, uint8_t crm, uint8_t op2, uint64_t value)
+void pal_execute_sys(uint8_t op0, uint8_t op1, uint8_t crn, uint8_t crm, uint8_t op2, uint64_t value)
 {
     int file_desc;
     int status;
@@ -19,6 +19,7 @@ void pal_execute_sys(uint8_t op1, uint8_t crn, uint8_t crm, uint8_t op2, uint64_
         return;
     }
 
+    sys_ops.in.op0 = op0;
     sys_ops.in.op1 = op1;
     sys_ops.in.crn = crn;
     sys_ops.in.crm = crm;

--- a/libpal/armv8a_aarch64_linux_ioctl/sysl.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/sysl.c
@@ -7,7 +7,7 @@
 
 #define DEVICE_FILE_NAME "/dev/devpal"
 
-uint64_t pal_execute_sysl(uint8_t op1, uint8_t crn, uint8_t crm, uint8_t op2)
+uint64_t pal_execute_sysl(uint8_t op0, uint8_t op1, uint8_t crn, uint8_t crm, uint8_t op2)
 {
     int file_desc;
     int status;
@@ -19,6 +19,7 @@ uint64_t pal_execute_sysl(uint8_t op1, uint8_t crn, uint8_t crm, uint8_t op2)
         return -1;
     }
 
+    sysl_ops.in.op0 = op0;
     sysl_ops.in.op1 = op1;
     sysl_ops.in.crn = crn;
     sysl_ops.in.crm = crm;

--- a/libpal/armv8a_aarch64_linux_ioctl/write_mem16.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/write_mem16.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "devpal_abi_generic.h"
+
+#define DEVICE_FILE_NAME "/dev/devpal"
+
+void pal_execute_write_mem16(uint64_t address, uint16_t value)
+{
+    int file_desc;
+    int status;
+    struct write_mem16_operands write_mem16_ops = {0};
+
+    file_desc = open(DEVICE_FILE_NAME, 0);
+    if (file_desc < 0) {
+        printf("[libpal] Can't open device file: %s\n", DEVICE_FILE_NAME);
+        return;
+    }
+
+    write_mem16_ops.in.address = address;
+    write_mem16_ops.in.value = value;
+    if(ioctl(file_desc, DEVPAL_EXECUTE_WRITE_MEM16, &write_mem16_ops)) {
+        printf("[libpal] write_mem16 ioctl failed\n");
+        return;
+    }
+}

--- a/libpal/armv8a_aarch64_linux_ioctl/write_mem32.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/write_mem32.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "devpal_abi_generic.h"
+
+#define DEVICE_FILE_NAME "/dev/devpal"
+
+void pal_execute_write_mem32(uint64_t address, uint32_t value)
+{
+    int file_desc;
+    int status;
+    struct write_mem32_operands write_mem32_ops = {0};
+
+    file_desc = open(DEVICE_FILE_NAME, 0);
+    if (file_desc < 0) {
+        printf("[libpal] Can't open device file: %s\n", DEVICE_FILE_NAME);
+        return;
+    }
+
+    write_mem32_ops.in.address = address;
+    write_mem32_ops.in.value = value;
+    if(ioctl(file_desc, DEVPAL_EXECUTE_WRITE_MEM32, &write_mem32_ops)) {
+        printf("[libpal] write_mem32 ioctl failed\n");
+        return;
+    }
+}

--- a/libpal/armv8a_aarch64_linux_ioctl/write_mem64.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/write_mem64.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "devpal_abi_generic.h"
+
+#define DEVICE_FILE_NAME "/dev/devpal"
+
+void pal_execute_write_mem64(uint64_t address, uint64_t value)
+{
+    int file_desc;
+    int status;
+    struct write_mem64_operands write_mem64_ops = {0};
+
+    file_desc = open(DEVICE_FILE_NAME, 0);
+    if (file_desc < 0) {
+        printf("[libpal] Can't open device file: %s\n", DEVICE_FILE_NAME);
+        return;
+    }
+
+    write_mem64_ops.in.address = address;
+    write_mem64_ops.in.value = value;
+    if(ioctl(file_desc, DEVPAL_EXECUTE_WRITE_MEM64, &write_mem64_ops)) {
+        printf("[libpal] write_mem64 ioctl failed\n");
+        return;
+    }
+}

--- a/libpal/armv8a_aarch64_linux_ioctl/write_mem8.c
+++ b/libpal/armv8a_aarch64_linux_ioctl/write_mem8.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "devpal_abi_generic.h"
+
+#define DEVICE_FILE_NAME "/dev/devpal"
+
+void pal_execute_write_mem8(uint64_t address, uint8_t value)
+{
+    int file_desc;
+    int status;
+    struct write_mem8_operands write_mem8_ops = {0};
+
+    file_desc = open(DEVICE_FILE_NAME, 0);
+    if (file_desc < 0) {
+        printf("[libpal] Can't open device file: %s\n", DEVICE_FILE_NAME);
+        return;
+    }
+
+    write_mem8_ops.in.address = address;
+    write_mem8_ops.in.value = value;
+    if(ioctl(file_desc, DEVPAL_EXECUTE_WRITE_MEM8, &write_mem8_ops)) {
+        printf("[libpal] write_mem8 ioctl failed\n");
+        return;
+    }
+}

--- a/pal/writer/access_mechanism/libpal.py
+++ b/pal/writer/access_mechanism/libpal.py
@@ -367,8 +367,9 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
 
     def __call_mrs_register_access_mechanism(self, outfile, register,
                                             access_mechanism, result):
-        outfile.write('{} = pal_execute_sysl({}, {}, {}, {});'.format(
+        outfile.write('{} = pal_execute_sysl({}, {}, {}, {}, {});'.format(
             result,
+            hex(access_mechanism.op0),
             hex(access_mechanism.op1),
             hex(access_mechanism.crn),
             hex(access_mechanism.crm),
@@ -378,7 +379,8 @@ class LibpalAccessMechanismWriter(AccessMechanismWriter):
 
     def __call_msr_register_access_mechanism(self, outfile, register,
                                        access_mechanism, value):
-        outfile.write('pal_execute_sys({}, {}, {}, {}, {});'.format(
+        outfile.write('pal_execute_sys({}, {}, {}, {}, {}, {});'.format(
+            hex(access_mechanism.op0),
             hex(access_mechanism.op1),
             hex(access_mechanism.crn),
             hex(access_mechanism.crm),

--- a/script/generate_armv8a_sys_shim.py
+++ b/script/generate_armv8a_sys_shim.py
@@ -1,0 +1,129 @@
+import os, sys
+from yaml import load, dump
+from yaml import CLoader as Loader, CDumper as Dumper
+
+dirpath = "/home/ubuntu/PAL/pal/data/armv8a/register/aarch64"
+mode = 'sys'
+
+switch_output_file_path = "/home/ubuntu/PAL/pal/devpal/linux/armv8a/aarch64/generated_%s_switch.c" % mode
+switch_output_list = []
+asm_output_file_path = "/home/ubuntu/PAL/pal/devpal/linux/armv8a/aarch64/%s_asm.h" % mode
+asm_output_list = []
+
+d = {}
+c = 1
+
+def write_to_file(s, output_file_path):
+    try:
+        infile = open(output_file_path, "w")
+        infile.write(s)  
+        infile.close()
+    except Exception as e:
+        msg = "Failed to write"
+        msg += ": " + str(e)
+        print(msg)
+
+def parse_access_mechanisms(yml, register_name):
+        global c
+        vector = 0
+        if not yml["access_mechanisms"]:
+            return
+
+        for am_yml in yml["access_mechanisms"]:
+
+            op0 = am_yml["op0"]
+            op1 = am_yml["op1"]
+            crn = am_yml["crn"]
+            crm = am_yml["crm"]
+            op2 = am_yml["op2"]
+
+            #print(op0, op1, crn, crm, op2)
+            #The switch vector the sys/sysl instruction encodin, the last 5 bits are not used for our purposes
+            vector |= (op0 & 3) << 19;
+            vector |= (op1 & 7) << 16;
+            vector |= (crn & 15) << 12;
+            vector |= (crm & 15) << 8;
+            vector |= (op2 & 7) << 5;
+            #print('%x' % vector)
+
+            if mode == "sysl":
+
+                if vector not in d:
+                    d[vector] = register_name
+                else:
+                    return
+                    '''print("Duplicate!")
+                    print("Vector %x" % vector)
+                    print(c, d[vector], "and", register_name)
+                    print("=" * 50)'''
+                    
+
+                case_format_string = "case 0x%x:\n\tvalue = pal_get_%s_inline();\n\tbreak;\n" % (vector, register_name)
+
+                asm_format_string = ("inline uint64_t pal_get_%s_inline(void)\n"
+                                    "{\n"
+                                    "\tuint64_t value = 0;\n"
+                                    "\t__asm__ volatile(\"mrs %%0, s%s_%s_c%s_c%s_%s\"\n"
+                                    "\t\t\t: \"=r\"(value));\n"
+                                    "\treturn value;\n"
+                                    "}\n"
+                                    ) % (register_name, op0, op1, crn, crm, op2)
+                #print(asm_format_string)
+
+                asm_output_list.append(asm_format_string)
+                switch_output_list.append(case_format_string)
+
+                break
+        
+            elif mode == "sys":
+                if vector not in d:
+                    d[vector] = register_name
+                else:
+                    return
+                    '''print("Duplicate!")
+                    print("Vector %x" % vector)
+                    print(c, d[vector], "and", register_name)
+                    print("=" * 50)'''
+                    
+
+                case_format_string = "case 0x%x:\n\tpal_set_%s_inline(value);\n\tbreak;\n" % (vector, register_name)
+
+                asm_format_string = ("inline void pal_set_%s_inline(uint64_t value)\n"
+                                    "{\n"
+                                    "\t__asm__ volatile(\"msr s%s_%s_c%s_c%s_%s, %%0\"\n"
+                                    "\t\t\t:\n"
+                                    "\t\t\t: \"r\"(value));\n"
+                                    "}\n"
+                                    ) % (register_name, op0, op1, crn, crm, op2)
+                #print(asm_format_string)
+
+                asm_output_list.append(asm_format_string)
+                switch_output_list.append(case_format_string)
+
+                break
+
+            
+
+if __name__ == "__main__":
+
+    os.chdir(dirpath)
+    register_files = os.listdir()
+    register_files.sort()
+    c = 0
+    for i in register_files:
+        try:
+            path = dirpath + '/' + i.strip()
+            with open(path, "r", encoding="utf8") as infile:
+                data = load(infile, Loader)
+                register_name = data[0]['name'].lower()
+                parse_access_mechanisms(data[0], register_name)
+
+        except Exception as e:
+            msg = "Failed to parse register file " + str(path)
+            msg += ": " + str(e)
+            print(msg)
+    output_string = ''.join(switch_output_list)
+    write_to_file(output_string, switch_output_file_path)
+    output_string = ''.join(asm_output_list)
+    write_to_file(output_string, asm_output_file_path)
+        

--- a/script/generate_armv8a_sys_shim.py
+++ b/script/generate_armv8a_sys_shim.py
@@ -2,12 +2,12 @@ import os, sys
 from yaml import load, dump
 from yaml import CLoader as Loader, CDumper as Dumper
 
-dirpath = "/home/ubuntu/PAL/pal/data/armv8a/register/aarch64"
-mode = 'sys'
+dirpath = "" # path to directory to run in
+mode = 'sys' # SYS ir SYSL
 
-switch_output_file_path = "/home/ubuntu/PAL/pal/devpal/linux/armv8a/aarch64/generated_%s_switch.c" % mode
+switch_output_file_path = "" # path to directory to file to be generated
 switch_output_list = []
-asm_output_file_path = "/home/ubuntu/PAL/pal/devpal/linux/armv8a/aarch64/%s_asm.h" % mode
+asm_output_file_path = "" # path to directory to file to be generated
 asm_output_list = []
 
 d = {}

--- a/script/generate_armv8a_sys_shim_complete.py
+++ b/script/generate_armv8a_sys_shim_complete.py
@@ -1,0 +1,60 @@
+import os, sys
+from yaml import load, dump
+from yaml import CLoader as Loader, CDumper as Dumper
+
+
+switch_output_file_path = "/home/ubuntu/PAL/pal/devpal/linux/armv8a/aarch64/all_perm_switch.c"
+switch_output_list = []
+asm_output_file_path = "/home/ubuntu/PAL/pal/devpal/linux/armv8a/aarch64/all_perm_asm.c"
+asm_output_list = []
+
+d = {}
+c = 1
+
+def write_to_file(s, output_file_path):
+    try:
+        infile = open(output_file_path, "w")
+        infile.write(s)  
+        infile.close()
+    except Exception as e:
+        msg = "Failed to write"
+        msg += ": " + str(e)
+        print(msg)
+
+            
+if __name__ == "__main__":
+
+    for vector in range(65536):
+        op0 = vector >> 14
+        op1 = (vector >> 11) & 7
+        crn = (vector >> 7) & 15
+        crm = (vector >> 3) & 15
+        op2 = vector & 7            
+
+        #print("%x" % vector)
+        #print(op0, op1, crn, crm, op2)
+
+        # To follow sys instruction convention
+        vector = vector << 5
+
+        case_format_string = "case 0x%x:\n\tvalue = pal_get_s%s_%s_c%s_c%s_%s_inline();\n\tbreak;\n" % (vector, op0, op1, crn, crm, op2)
+
+        asm_format_string = ("inline uint64_t pal_get_s%s_%s_c%s_c%s_%s_inline(void)\n"
+                            "{\n"
+                            "\tuint64_t value = 0;\n"
+                            "\t__asm__ volatile(\"mrs %%0, s%s_%s_c%s_c%s_%s\"\n"
+                            "\t\t\t: \"=r\"(value));\n"
+                            "\treturn value;\n"
+                            "}\n"
+                            ) % (op0, op1, crn, crm, op2, op0, op1, crn, crm, op2)
+        #print(asm_format_string)
+
+        asm_output_list.append(asm_format_string)
+        switch_output_list.append(case_format_string)       
+
+
+    output_string = ''.join(switch_output_list)
+    write_to_file(output_string, switch_output_file_path)
+    output_string = ''.join(asm_output_list)
+    write_to_file(output_string, asm_output_file_path)
+        

--- a/script/generate_armv8a_sys_shim_complete.py
+++ b/script/generate_armv8a_sys_shim_complete.py
@@ -3,9 +3,9 @@ from yaml import load, dump
 from yaml import CLoader as Loader, CDumper as Dumper
 
 
-switch_output_file_path = "/home/ubuntu/PAL/pal/devpal/linux/armv8a/aarch64/all_perm_switch.c"
+switch_output_file_path = "" # path to directory to file to be generated
 switch_output_list = []
-asm_output_file_path = "/home/ubuntu/PAL/pal/devpal/linux/armv8a/aarch64/all_perm_asm.c"
+asm_output_file_path = "" # path to directory to file to be generated
 asm_output_list = []
 
 d = {}


### PR DESCRIPTION
This pull request introduces a Chipsec-for-ARM capability, described in the following discussion: https://github.com/Bareflank/pal/discussions/84

The first version of this feature introduces support for SMC, HVC, system registers, and memory access primitives. Helper scripts are also included to re-create some of the implementation details of the `devpal` driver.

The approach taken does not rely on writable+executable memory pages (described in the original discussion). Instead, it pre-compiles all possibilities for the `MSR` and `MRS` instructions to access any system register from within the `devpal` driver.

An example program is included, and will be improved over time as more features are added.